### PR TITLE
Align frontend and backend AI onboarding endpoint

### DIFF
--- a/src/api/ai.ts
+++ b/src/api/ai.ts
@@ -1,13 +1,13 @@
 import api from './api';
 
 // Description: Process onboarding responses with AI to create enhanced life plan or project plan
-// Endpoint: POST /api/ai/process-onboarding
+// Endpoint: POST /api/ai/onboarding
 // Request: { responses: Record<string, any>, planType: 'life' | 'project' }
 // Response: { success: boolean, plan: any, message: string, usedFallback?: boolean }
 export const processOnboardingWithAI = async (responses: Record<string, any>, planType: 'life' | 'project') => {
   try {
     console.log('AI API: Processing onboarding with AI', { planType, responseKeys: Object.keys(responses) });
-    const response = await api.post('/api/ai/process-onboarding', {
+    const response = await api.post('/api/ai/onboarding', {
       responses,
       planType
     });


### PR DESCRIPTION
## Summary
- update `processOnboardingWithAI` frontend call to use `/api/ai/onboarding`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687efc4858708326be588e3188705781