### PR TITLE
Remove client dist artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+client/dist/
 .env
 lifepilot.db
 *.log


### PR DESCRIPTION
## Summary
- ignore `client/dist/`

There was no `client/dist` directory in the repo, so no files were removed.


------
https://chatgpt.com/codex/tasks/task_e_687efcc2a0608326b4ab57b5365ada1f