### PR TITLE
Add .env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to .env and fill in the values
+
+# Backend secrets
+JWT_SECRET=
+JWT_REFRESH_SECRET=
+OPENAI_API_KEY=
+PORT=3000
+
+# Frontend keys
+VITE_OPENAI_API_KEY=
+VITE_ELEVENLABS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Create the following products and prices in your Stripe dashboard:
 
 ### 2. Environment Variables
 
-Add the following variables to an `.env` file in the project root. Frontend variables
-must be prefixed with `VITE_` so Vite can expose them to the client.
+Copy the provided `.env.example` file to `.env` in the project root and fill in the values.
+Frontend variables must be prefixed with `VITE_` so Vite can expose them to the client.
 
 #### Frontend
 - `VITE_OPENAI_API_KEY` – OpenAI key used by the browser (optional)


### PR DESCRIPTION
## Summary
- add `.env.example` documenting backend & frontend environment variables
- update README to instruct users to copy `.env.example` to `.env`

## Testing
- `npm run build` *(fails: Could not resolve entry module `index.html`)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687f00194e608326b051b8d84f3d9d45