### PR TITLE
Add onboarding and settings pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { LandingPage } from "./pages/LandingPage"
 import { PricingPage } from "./components/subscription/PricingPage"
 import { SubscriptionManager } from "./components/subscription/SubscriptionManager"
 import { ProtectedRoute } from "./components/ProtectedRoute"
+import { Onboarding } from "./pages/Onboarding"
+import { SettingsPage } from "./pages/Settings"
 
 function App() {
   console.log("App component is rendering");
@@ -52,6 +54,18 @@ function App() {
             (() => {
               console.log("Rendering SubscriptionManager for route /subscription");
               return <ProtectedRoute> <SubscriptionManager /> </ProtectedRoute>;
+            })()
+          } />
+          <Route path="/onboarding" element={
+            (() => {
+              console.log("Rendering Onboarding for route /onboarding");
+              return <ProtectedRoute> <Onboarding /> </ProtectedRoute>;
+            })()
+          } />
+          <Route path="/settings" element={
+            (() => {
+              console.log("Rendering SettingsPage for route /settings");
+              return <ProtectedRoute> <SettingsPage /> </ProtectedRoute>;
             })()
           } />
         </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,12 @@ export function Header() {
       <div className="flex h-16 items-center justify-between px-6">
         <div className="text-xl font-bold" onClick={navigate("/")}>Home</div>
         <div className="flex items-center gap-4">
+          <Button variant="ghost" onClick={() => navigate('/onboarding')}>
+            Onboarding
+          </Button>
+          <Button variant="ghost" onClick={() => navigate('/settings')}>
+            Settings
+          </Button>
           <ThemeToggle />
           <Button variant="ghost" size="icon" onClick={handleLogout}>
             <LogOut className="h-5 w-5" />

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -9,7 +9,6 @@ import { useNavigate } from 'react-router-dom';
 import { useMobile } from '@/hooks/useMobile';
 import { useProjectStorage } from '@/hooks/useProjectStorage';
 import { ProfileModal } from './modals/ProfileModal';
-import { SettingsModal } from './modals/SettingsModal';
 
 interface DashboardHeaderProps {
   onMenuToggle?: () => void;
@@ -22,7 +21,6 @@ export function DashboardHeader({ onMenuToggle }: DashboardHeaderProps) {
   const { activeProject } = useProjectStorage();
   const [rippleSettings, setRippleSettings] = useState<{ x: number; y: number; show: boolean }>({ x: 0, y: 0, show: false });
   const [showProfileModal, setShowProfileModal] = useState(false);
-  const [showSettingsModal, setShowSettingsModal] = useState(false);
 
   const handleLogout = () => {
     logout();
@@ -98,16 +96,23 @@ export function DashboardHeader({ onMenuToggle }: DashboardHeaderProps) {
                   <DropdownMenuSeparator className="bg-gray-700" />
                 </>
               )}
-              <DropdownMenuItem 
+              <DropdownMenuItem
                 className="hover:bg-gray-800 cursor-pointer"
                 onClick={() => setShowProfileModal(true)}
               >
                 <User className="mr-2 h-4 w-4" />
                 <span>Profile</span>
               </DropdownMenuItem>
-              <DropdownMenuItem 
+              <DropdownMenuItem
                 className="hover:bg-gray-800 cursor-pointer"
-                onClick={() => setShowSettingsModal(true)}
+                onClick={() => navigate('/onboarding')}
+              >
+                <Crown className="mr-2 h-4 w-4" />
+                <span>Onboarding</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="hover:bg-gray-800 cursor-pointer"
+                onClick={() => navigate('/settings')}
               >
                 <Settings className="mr-2 h-4 w-4" />
                 <span>Settings</span>
@@ -128,11 +133,6 @@ export function DashboardHeader({ onMenuToggle }: DashboardHeaderProps) {
         onClose={() => setShowProfileModal(false)} 
       />
 
-      {/* Settings Modal */}
-      <SettingsModal 
-        isOpen={showSettingsModal} 
-        onClose={() => setShowSettingsModal(false)} 
-      />
     </>
   );
 }

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useProjectStorage } from '@/hooks/useProjectStorage';
+import { useNavigate } from 'react-router-dom';
+
+export function Onboarding() {
+  const [step, setStep] = useState(1);
+  const [valueInput, setValueInput] = useState('');
+  const [goalInput, setGoalInput] = useState('');
+  const [values, setValues] = useState<string[]>([]);
+  const [goals, setGoals] = useState<string[]>([]);
+  const { createProject } = useProjectStorage();
+  const navigate = useNavigate();
+
+  const addValue = () => {
+    if (valueInput.trim()) {
+      setValues(prev => [...prev, valueInput.trim()]);
+      setValueInput('');
+    }
+  };
+
+  const addGoal = () => {
+    if (goalInput.trim()) {
+      setGoals(prev => [...prev, goalInput.trim()]);
+      setGoalInput('');
+    }
+  };
+
+  const finish = () => {
+    createProject({
+      name: 'My LifePlan',
+      icon: '🌟',
+      category: 'personal',
+      profile: {
+        vision: '',
+        metrics: values,
+        objective: goals.join(', '),
+      },
+      character: {
+        role: 'Novice',
+        level: 1,
+        xp: 0,
+        xpToNext: 100,
+        jobPerk: '',
+      },
+      milestones: [],
+      widgets: [],
+      chatHistory: [],
+    });
+    navigate('/dashboard');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="w-full max-w-lg">
+        <CardHeader>
+          <CardTitle>Welcome to LifePilot</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {step === 1 && (
+            <div className="space-y-2">
+              <p className="font-medium">What values are most important to you?</p>
+              <div className="flex gap-2">
+                <Input
+                  value={valueInput}
+                  onChange={e => setValueInput(e.target.value)}
+                  placeholder="Add a value"
+                />
+                <Button onClick={addValue}>Add</Button>
+              </div>
+              <ul className="list-disc pl-5 space-y-1">
+                {values.map((v, i) => (
+                  <li key={i}>{v}</li>
+                ))}
+              </ul>
+              <div className="text-right">
+                <Button onClick={() => setStep(2)} disabled={values.length === 0}>
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+          {step === 2 && (
+            <div className="space-y-2">
+              <p className="font-medium">List a few top goals you want to achieve.</p>
+              <div className="flex gap-2">
+                <Input
+                  value={goalInput}
+                  onChange={e => setGoalInput(e.target.value)}
+                  placeholder="Add a goal"
+                />
+                <Button onClick={addGoal}>Add</Button>
+              </div>
+              <ul className="list-disc pl-5 space-y-1">
+                {goals.map((g, i) => (
+                  <li key={i}>{g}</li>
+                ))}
+              </ul>
+              <div className="flex justify-between">
+                <Button variant="outline" onClick={() => setStep(1)}>
+                  Back
+                </Button>
+                <Button onClick={finish} disabled={goals.length === 0}>
+                  Finish
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default Onboarding;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,69 @@
+import React, { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+
+export function SettingsPage() {
+  const [voiceEnabled, setVoiceEnabled] = useState<boolean>(false);
+  const [voiceLanguage, setVoiceLanguage] = useState('en-US');
+  const [apiKey, setApiKey] = useState('');
+  const [syncStatus, setSyncStatus] = useState('disconnected');
+
+  useEffect(() => {
+    const storedKey = localStorage.getItem('lifepilot_api_key');
+    if (storedKey) setApiKey(storedKey);
+  }, []);
+
+  const saveSettings = () => {
+    localStorage.setItem('lifepilot_api_key', apiKey);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="w-full max-w-lg space-y-4">
+        <CardHeader>
+          <CardTitle>Settings</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <Label>Enable Voice</Label>
+            <Switch checked={voiceEnabled} onCheckedChange={setVoiceEnabled} />
+          </div>
+          <div className="space-y-2">
+            <Label>Voice Language</Label>
+            <Select value={voiceLanguage} onValueChange={setVoiceLanguage}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="en-US">English (US)</SelectItem>
+                <SelectItem value="en-GB">English (UK)</SelectItem>
+                <SelectItem value="es-ES">Spanish</SelectItem>
+                <SelectItem value="fr-FR">French</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>OpenAI API Key</Label>
+            <Input
+              type="password"
+              value={apiKey}
+              onChange={e => setApiKey(e.target.value)}
+              placeholder="sk-..."
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>ElectricSQL Sync Status</Label>
+            <p className="text-sm text-muted-foreground">{syncStatus}</p>
+          </div>
+          <Button onClick={saveSettings}>Save</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default SettingsPage;


### PR DESCRIPTION
## Summary
- introduce an `Onboarding` flow to capture values and goals
- create a `Settings` page for voice and API key preferences
- wire up routes for onboarding and settings
- update headers with links to the new pages

## Testing
- `yarn test` *(fails: Error: no test specified)*
- `yarn build` *(fails to resolve entry module)*

------
https://chatgpt.com/codex/tasks/task_e_687f8b953c208326bbb69bce5eb35610