### PR TITLE
Add responsive dashboard grid and widget enhancements

### DIFF
--- a/src/api/widgets.ts
+++ b/src/api/widgets.ts
@@ -269,3 +269,41 @@ export const generateWidgets = async (context: string, activeWidgets: string[] =
   //   throw new Error(error?.response?.data?.error || error.message);
   // }
 };
+
+// Description: Update widgets with new data based on chat context
+// Endpoint: POST /widgets/update
+// Request: { context: string, widgets: WidgetData[] }
+// Response: { widgets: WidgetData[] }
+export const updateWidgets = async (context: string, widgets: any[]) => {
+  return new Promise<{ widgets: any[] }>((resolve) => {
+    setTimeout(() => {
+      const lower = context.toLowerCase();
+      const updated = widgets.map((w) => {
+        if (w.id === 'goals-progress' && lower.includes('goal')) {
+          return {
+            ...w,
+            data: w.data.map((g: any) => ({
+              ...g,
+              progress: Math.min(100, g.progress + 5)
+            }))
+          };
+        }
+        if (w.id === 'habit-streaks' && lower.includes('habit')) {
+          return {
+            ...w,
+            data: w.data.map((h: any) => ({
+              ...h,
+              streak: h.streak + 1
+            }))
+          };
+        }
+        if (w.id === 'mood-tracker' && lower.includes('mood')) {
+          const mood = Math.max(1, Math.min(5, Math.round(Math.random() * 5)));
+          return { ...w, data: [...w.data.slice(1), { date: 'Today', mood }] };
+        }
+        return w;
+      });
+      resolve({ widgets: updated });
+    }, 300);
+  });
+};

--- a/src/components/dashboard/AuraLayout.tsx
+++ b/src/components/dashboard/AuraLayout.tsx
@@ -286,9 +286,7 @@ function AuraLayoutContent() {
         {/* Widget Grid - Full Width - only show if we have an active project */}
         {activeProject && (
           <main className="px-4 py-4" style={{ paddingBottom: '72px' }}>
-            <div className="grid gap-4 grid-cols-3 md:grid-cols-4 lg:grid-cols-5 max-w-7xl mx-auto">
-              <LiveDashboard onWidgetClick={openWidgetModal} />
-            </div>
+            <LiveDashboard onWidgetClick={openWidgetModal} />
 
             <FloatingAuraSphere
               onActivate={() => setIsChatExpanded(true)}

--- a/src/components/dashboard/LiveDashboard.tsx
+++ b/src/components/dashboard/LiveDashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { useChatContext } from '@/contexts/ChatContext';
 import { UniversalWidget } from './widgets/UniversalWidget';
@@ -8,8 +8,29 @@ interface LiveDashboardProps {
   onWidgetClick?: (widget: any) => void;
 }
 
+function useResponsiveColumns() {
+  const getColumns = () => {
+    if (typeof window === 'undefined') return 1;
+    const width = window.innerWidth;
+    if (width < 640) return 1;
+    if (width < 1024) return 2;
+    return 3;
+  };
+
+  const [columns, setColumns] = useState(getColumns());
+
+  useEffect(() => {
+    const handleResize = () => setColumns(getColumns());
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return columns;
+}
+
 export function LiveDashboard({ onWidgetClick }: LiveDashboardProps) {
   const { activeWidgets, handleWidgetAction } = useChatContext();
+  const columns = useResponsiveColumns();
 
   if (activeWidgets.length === 0) {
     // Show empty state with placeholder widgets
@@ -23,7 +44,10 @@ export function LiveDashboard({ onWidgetClick }: LiveDashboardProps) {
   }
 
   return (
-    <>
+    <div
+      className="grid gap-4"
+      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+    >
       {activeWidgets.map((widget, index) => (
         <motion.div
           key={widget.id}
@@ -44,6 +68,6 @@ export function LiveDashboard({ onWidgetClick }: LiveDashboardProps) {
       {Array.from({ length: Math.max(0, 9 - activeWidgets.length) }).map((_, index) => (
         <EmptyWidget key={`empty-${index}`} index={activeWidgets.length + index} />
       ))}
-    </>
+    </div>
   );
 }

--- a/src/components/dashboard/widgets/CoreValuesWheel.tsx
+++ b/src/components/dashboard/widgets/CoreValuesWheel.tsx
@@ -22,8 +22,8 @@ export function CoreValuesWheel(props: any) {
   return (
     <motion.div {...props} className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 h-64">
       <h3 className="text-lg font-semibold text-white mb-4">Core Values</h3>
-      
-      <ResponsiveContainer width="100%" height="100%">
+
+      <ResponsiveContainer width="100%" height="70%">
         <PieChart>
           <Pie
             data={valuesData}
@@ -38,16 +38,28 @@ export function CoreValuesWheel(props: any) {
               <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
             ))}
           </Pie>
-          <Tooltip 
-            contentStyle={{ 
-              backgroundColor: 'rgba(0,0,0,0.8)', 
-              border: 'none', 
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'rgba(0,0,0,0.8)',
+              border: 'none',
               borderRadius: '8px',
               color: 'white'
-            }} 
+            }}
           />
         </PieChart>
       </ResponsiveContainer>
+
+      <div className="mt-2 grid grid-cols-3 gap-1 text-xs text-white/80">
+        {valuesData?.map((v: any, idx: number) => (
+          <div key={v.name} className="flex items-center space-x-1">
+            <span
+              className="w-2 h-2 rounded-sm"
+              style={{ backgroundColor: COLORS[idx % COLORS.length] }}
+            />
+            <span>{v.name}</span>
+          </div>
+        ))}
+      </div>
     </motion.div>
   );
 }

--- a/src/components/dashboard/widgets/DailyFocusPanel.tsx
+++ b/src/components/dashboard/widgets/DailyFocusPanel.tsx
@@ -30,6 +30,8 @@ export function DailyFocusPanel(props: any) {
     priority: task.priority
   })) || [];
 
+  const remaining = checklistItems.filter((c) => !c.completed).length;
+
   return (
     <motion.div {...props} className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 h-64">
       <div className="flex items-center space-x-2 mb-4">
@@ -43,6 +45,10 @@ export function DailyFocusPanel(props: any) {
         showPriority={true}
         maxHeight="max-h-40"
       />
+
+      <div className="mt-4 text-xs text-white/70 text-center">
+        {remaining} task{remaining !== 1 ? 's' : ''} remaining
+      </div>
     </motion.div>
   );
 }

--- a/src/components/dashboard/widgets/GoalProgressCards.tsx
+++ b/src/components/dashboard/widgets/GoalProgressCards.tsx
@@ -3,8 +3,14 @@ import { motion } from 'framer-motion';
 import { Progress } from '@/components/ui/progress';
 import { useGoalsData } from '@/api/dashboard';
 import { Target, TrendingUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
-export function GoalProgressCards(props: any) {
+interface GoalProgressCardsProps {
+  onViewAll?: () => void;
+  className?: string;
+}
+
+export function GoalProgressCards({ onViewAll, className = '', ...props }: GoalProgressCardsProps & any) {
   const { data: goalsData, isLoading } = useGoalsData();
 
   if (isLoading) {
@@ -23,7 +29,10 @@ export function GoalProgressCards(props: any) {
   }
 
   return (
-    <motion.div {...props} className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 h-64 overflow-y-auto">
+    <motion.div
+      {...props}
+      className={`bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 h-64 overflow-y-auto ${className}`}
+    >
       <div className="flex items-center space-x-2 mb-4">
         <Target className="w-5 h-5 text-blue-400" />
         <h3 className="text-lg font-semibold text-white">Goal Progress</h3>
@@ -44,6 +53,14 @@ export function GoalProgressCards(props: any) {
           </div>
         ))}
       </div>
+
+      {onViewAll && (
+        <div className="mt-4">
+          <Button size="sm" variant="secondary" className="w-full" onClick={onViewAll}>
+            View All
+          </Button>
+        </div>
+      )}
     </motion.div>
   );
 }

--- a/src/components/dashboard/widgets/HabitStreaks.tsx
+++ b/src/components/dashboard/widgets/HabitStreaks.tsx
@@ -2,8 +2,13 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { useHabitsData } from '@/api/dashboard';
 import { Flame, Calendar, CheckCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
-export function HabitStreaks(props: any) {
+interface HabitStreaksProps {
+  onAddHabit?: () => void;
+  className?: string;
+}
+export function HabitStreaks({ onAddHabit, className = '', ...props }: HabitStreaksProps & any) {
   const { data: habitsData, isLoading } = useHabitsData();
 
   if (isLoading) {
@@ -22,7 +27,10 @@ export function HabitStreaks(props: any) {
   }
 
   return (
-    <motion.div {...props} className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 h-64 overflow-y-auto">
+    <motion.div
+      {...props}
+      className={`bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 h-64 overflow-y-auto ${className}`}
+    >
       <div className="flex items-center space-x-2 mb-4">
         <Flame className="w-5 h-5 text-orange-400" />
         <h3 className="text-lg font-semibold text-white">Habit Streaks</h3>
@@ -69,6 +77,14 @@ export function HabitStreaks(props: any) {
           </motion.div>
         ))}
       </div>
+
+      {onAddHabit && (
+        <div className="mt-4">
+          <Button size="sm" variant="secondary" className="w-full" onClick={onAddHabit}>
+            Add Habit
+          </Button>
+        </div>
+      )}
     </motion.div>
   );
 }

--- a/src/components/dashboard/widgets/MoodTracker.tsx
+++ b/src/components/dashboard/widgets/MoodTracker.tsx
@@ -28,6 +28,13 @@ export function MoodTracker(props: any) {
 
   const currentMood = moodData?.[moodData.length - 1]?.mood || 3;
   const MoodIcon = moodIcons[currentMood as keyof typeof moodIcons];
+  const avgMood =
+    moodData && moodData.length
+      ? (
+          moodData.reduce((sum: number, d: any) => sum + d.mood, 0) /
+          moodData.length
+        ).toFixed(1)
+      : '3';
 
   return (
     <motion.div {...props} className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 h-64">
@@ -72,6 +79,8 @@ export function MoodTracker(props: any) {
           />
         </LineChart>
       </ResponsiveContainer>
+
+      <div className="mt-2 text-xs text-white/70 text-center">Avg mood: {avgMood}</div>
     </motion.div>
   );
 }

--- a/src/components/dashboard/widgets/SkillsRadar.tsx
+++ b/src/components/dashboard/widgets/SkillsRadar.tsx
@@ -20,8 +20,8 @@ export function SkillsRadar(props: any) {
   return (
     <motion.div {...props} className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 h-64">
       <h3 className="text-lg font-semibold text-white mb-4">Skills Radar</h3>
-      
-      <ResponsiveContainer width="100%" height="100%">
+
+      <ResponsiveContainer width="100%" height="70%">
         <RadarChart data={skillsData}>
           <PolarGrid stroke="rgba(255,255,255,0.2)" />
           <PolarAngleAxis dataKey="skill" tick={{ fill: 'white', fontSize: 12 }} />
@@ -49,6 +49,17 @@ export function SkillsRadar(props: any) {
           />
         </RadarChart>
       </ResponsiveContainer>
+
+      <div className="mt-2 flex justify-center space-x-4 text-xs text-white/80">
+        <div className="flex items-center space-x-1">
+          <span className="w-2 h-2 bg-blue-500 inline-block" />
+          <span>Current</span>
+        </div>
+        <div className="flex items-center space-x-1">
+          <span className="w-2 h-2 bg-green-500 inline-block" />
+          <span>Target</span>
+        </div>
+      </div>
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- make dashboard grid responsive to screen width
- open widget details from Aura layout
- show legends and buttons on various widgets
- compute and update widgets via new API

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f8b8f945c8326b75b3e43f15114dc