### PR TITLE
Add voice input and TTS hooks

### DIFF
--- a/src/components/dashboard/BottomChatSection.tsx
+++ b/src/components/dashboard/BottomChatSection.tsx
@@ -6,6 +6,8 @@ import { Send, Mic, MicOff, ChevronDown, ChevronUp } from 'lucide-react';
 import { ChatMessage } from './ChatMessage';
 import { useChatContext } from '@/contexts/ChatContext';
 import { AuraMemoryService } from './AuraLayout';
+import { useVoiceInput } from '@/hooks/useVoiceInput';
+import { useTextToSpeech } from '@/hooks/useTextToSpeech';
 
 interface BottomChatSectionProps {
   isExpanded: boolean;
@@ -14,11 +16,12 @@ interface BottomChatSectionProps {
 
 export function BottomChatSection({ isExpanded, onToggle }: BottomChatSectionProps) {
   const [inputValue, setInputValue] = useState('');
-  const [isListening, setIsListening] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const { messages, sendMessage, auraState, setAuraState } = useChatContext();
+  const { startRecording, stopRecording, transcript, setTranscript, isRecording } = useVoiceInput();
+  const { speak, isSpeaking } = useTextToSpeech();
 
   // Load conversation history from AuraMemoryService
   const [conversationHistory, setConversationHistory] = useState<Array<{ sender: string; text: string; timestamp: string }>>([]);
@@ -37,10 +40,11 @@ export function BottomChatSection({ isExpanded, onToggle }: BottomChatSectionPro
     scrollToBottom();
   }, [conversationHistory]);
 
-  const handleSendMessage = async () => {
-    if (!inputValue.trim()) return;
+  const handleSendMessage = async (text?: string) => {
+    const messageToSend = (text ?? inputValue).trim();
+    if (!messageToSend) return;
 
-    const userMessage = inputValue.trim();
+    const userMessage = messageToSend;
     console.log("BottomChatSection - Sending message:", userMessage);
     setInputValue('');
 
@@ -75,6 +79,7 @@ export function BottomChatSection({ isExpanded, onToggle }: BottomChatSectionPro
       setConversationHistory(finalHistory);
 
       setAuraState('speaking');
+      speak(response);
       setTimeout(() => setAuraState('idle'), 2000);
     } catch (error) {
       console.error('Error sending message:', error);
@@ -89,9 +94,30 @@ export function BottomChatSection({ isExpanded, onToggle }: BottomChatSectionPro
   };
 
   const toggleVoiceInput = () => {
-    setIsListening(!isListening);
-    setAuraState(isListening ? 'idle' : 'listening');
+    if (isRecording) {
+      stopRecording();
+      setAuraState('idle');
+    } else {
+      setTranscript('');
+      startRecording();
+      setAuraState('listening');
+    }
   };
+
+  useEffect(() => {
+    if (!isRecording && transcript) {
+      handleSendMessage(transcript);
+      setTranscript('');
+    }
+  }, [isRecording, transcript]);
+
+  useEffect(() => {
+    if (isSpeaking) {
+      setAuraState('speaking');
+    } else if (auraState === 'speaking') {
+      setAuraState('idle');
+    }
+  }, [isSpeaking]);
 
   // Get recent messages for display (last 10)
   const recentMessages = conversationHistory.slice(-10);
@@ -181,11 +207,14 @@ export function BottomChatSection({ isExpanded, onToggle }: BottomChatSectionPro
               variant="ghost"
               size="icon"
               className={`text-white hover:bg-white/10 ${
-                isListening ? 'bg-red-500/20 text-red-400' : ''
+                isRecording ? 'bg-red-500/20 text-red-400' : ''
               }`}
             >
-              {isListening ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+              {isRecording ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
             </Button>
+            {isRecording && (
+              <span className="text-xs text-red-400">Listening...</span>
+            )}
             <Button
               onClick={handleSendMessage}
               disabled={!inputValue.trim()}

--- a/src/components/dashboard/FloatingAuraSphere.tsx
+++ b/src/components/dashboard/FloatingAuraSphere.tsx
@@ -12,6 +12,7 @@ export function FloatingAuraSphere({ onActivate }: FloatingAuraSphereProps) {
   const controls = useAnimation();
   const { auraState } = useChatContext();
   const [isHovered, setIsHovered] = useState(false);
+  const isActive = auraState === 'listening' || auraState === 'speaking';
   
   // Use smooth position animation
   const { x, y } = useSpherePosition();
@@ -132,7 +133,7 @@ export function FloatingAuraSphere({ onActivate }: FloatingAuraSphereProps) {
         className="absolute inset-0 rounded-full"
         animate={{
           scale: isHovered ? [1, 1.3, 1] : [1, 1.1, 1],
-          opacity: [0.3, 0.6, 0.3]
+          opacity: isActive ? [0.5, 0.9, 0.5] : [0.3, 0.6, 0.3]
         }}
         transition={{
           duration: 2,
@@ -155,8 +156,8 @@ export function FloatingAuraSphere({ onActivate }: FloatingAuraSphereProps) {
         style={{
           background: getSphereColor(),
           boxShadow: `
-            0 0 20px rgba(139, 92, 246, 0.4),
-            0 0 40px rgba(139, 92, 246, 0.2),
+            0 0 ${isActive ? 30 : 20}px rgba(139, 92, 246, 0.4),
+            0 0 ${isActive ? 60 : 40}px rgba(139, 92, 246, 0.2),
             inset 0 2px 4px rgba(255, 255, 255, 0.3)
           `
         }}

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -26,8 +26,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const messages = activeProject?.chatHistory || [];
   const activeWidgets = activeProject?.widgets || [];
 
-  const sendMessage = useCallback(async (content: string) => {
-    if (!activeProject) return;
+  const sendMessage = useCallback(async (content: string): Promise<string> => {
+    if (!activeProject) return '';
 
     const userMessage: Message = {
       id: Date.now().toString(),
@@ -64,9 +64,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
       setAuraState('speaking');
       setTimeout(() => setAuraState('idle'), 2000);
+      return response.message;
     } catch (error) {
       console.error('Error sending message:', error);
       setAuraState('idle');
+      return '';
     }
   }, [activeProject, messages, activeWidgets, updateProject]);
 

--- a/src/hooks/useTextToSpeech.ts
+++ b/src/hooks/useTextToSpeech.ts
@@ -1,0 +1,36 @@
+import { useState, useCallback } from 'react'
+import api from '@/api/api'
+
+export function useTextToSpeech() {
+  const [isSpeaking, setIsSpeaking] = useState(false)
+
+  const speak = useCallback(async (text: string) => {
+    if (!text) return
+    try {
+      if (import.meta.env.VITE_ELEVENLABS_API_KEY) {
+        const response = await api.post('/ai/tts', { text }, { responseType: 'blob' })
+        const url = URL.createObjectURL(response.data)
+        const audio = new Audio(url)
+        setIsSpeaking(true)
+        audio.onended = () => {
+          setIsSpeaking(false)
+          URL.revokeObjectURL(url)
+        }
+        await audio.play()
+      } else {
+        const utterance = new SpeechSynthesisUtterance(text)
+        utterance.onend = () => setIsSpeaking(false)
+        setIsSpeaking(true)
+        speechSynthesis.speak(utterance)
+      }
+    } catch (err) {
+      console.error('TTS error', err)
+      const utter = new SpeechSynthesisUtterance(text)
+      utter.onend = () => setIsSpeaking(false)
+      setIsSpeaking(true)
+      speechSynthesis.speak(utter)
+    }
+  }, [])
+
+  return { speak, isSpeaking }
+}

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -1,0 +1,68 @@
+import { useState, useRef, useCallback } from 'react'
+import api from '@/api/api'
+
+export function useVoiceInput() {
+  const [isRecording, setIsRecording] = useState(false)
+  const [transcript, setTranscript] = useState('')
+  const recognitionRef = useRef<any>(null)
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+
+  const start = useCallback(async () => {
+    if (isRecording) return
+    if ((window as any).SpeechRecognition || (window as any).webkitSpeechRecognition) {
+      const Rec = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+      const recognition = new Rec()
+      recognition.lang = 'en-US'
+      recognition.interimResults = false
+      recognition.onresult = e => {
+        const text = Array.from(e.results).map(r => r[0].transcript).join(' ')
+        setTranscript(text)
+      }
+      recognition.onend = () => setIsRecording(false)
+      recognition.onerror = () => setIsRecording(false)
+      recognition.start()
+      recognitionRef.current = recognition
+      setIsRecording(true)
+    } else {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+        const recorder = new MediaRecorder(stream)
+        chunksRef.current = []
+        recorder.ondataavailable = e => {
+          if (e.data.size > 0) chunksRef.current.push(e.data)
+        }
+        recorder.onstop = async () => {
+          const blob = new Blob(chunksRef.current, { type: 'audio/webm' })
+          try {
+            const formData = new FormData()
+            formData.append('file', blob, 'recording.webm')
+            const res = await api.post('/ai/whisper', formData, {
+              headers: { 'Content-Type': 'multipart/form-data' }
+            })
+            if (res.data?.text) setTranscript(res.data.text)
+          } catch (err) {
+            console.error('Whisper transcription failed', err)
+          }
+          setIsRecording(false)
+        }
+        recorder.start()
+        mediaRecorderRef.current = recorder
+        setIsRecording(true)
+      } catch (err) {
+        console.error('Unable to access microphone', err)
+      }
+    }
+  }, [isRecording])
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.stop()
+    recognitionRef.current = null
+    if (mediaRecorderRef.current) {
+      mediaRecorderRef.current.stop()
+      mediaRecorderRef.current = null
+    }
+  }, [])
+
+  return { startRecording: start, stopRecording: stop, transcript, setTranscript, isRecording }
+}


### PR DESCRIPTION
## Summary
- add hooks for microphone capture and text-to-speech
- speak Aura replies and trigger voice listening from chat section
- glow FloatingAuraSphere when speech is active
- return response text from `sendMessage`

## Testing
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_687f8b86f6b88326b1ccb9b87403c2d4