### PR TITLE
Switch to client-side speech APIs

### DIFF
--- a/src/hooks/useTextToSpeech.ts
+++ b/src/hooks/useTextToSpeech.ts
@@ -1,5 +1,4 @@
 import { useState, useCallback } from 'react'
-import api from '@/api/api'
 
 export function useTextToSpeech() {
   const [isSpeaking, setIsSpeaking] = useState(false)
@@ -7,9 +6,21 @@ export function useTextToSpeech() {
   const speak = useCallback(async (text: string) => {
     if (!text) return
     try {
-      if (import.meta.env.VITE_ELEVENLABS_API_KEY) {
-        const response = await api.post('/ai/tts', { text }, { responseType: 'blob' })
-        const url = URL.createObjectURL(response.data)
+      const apiKey = import.meta.env.VITE_ELEVENLABS_API_KEY
+
+      if (apiKey) {
+        const voiceId = '21m00Tcm4TlvDq8ikWAM'
+        const response = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'xi-api-key': apiKey
+          },
+          body: JSON.stringify({ text })
+        })
+
+        const blob = await response.blob()
+        const url = URL.createObjectURL(blob)
         const audio = new Audio(url)
         setIsSpeaking(true)
         audio.onended = () => {

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -1,5 +1,4 @@
 import { useState, useRef, useCallback } from 'react'
-import api from '@/api/api'
 
 export function useVoiceInput() {
   const [isRecording, setIsRecording] = useState(false)
@@ -37,10 +36,20 @@ export function useVoiceInput() {
           try {
             const formData = new FormData()
             formData.append('file', blob, 'recording.webm')
-            const res = await api.post('/ai/whisper', formData, {
-              headers: { 'Content-Type': 'multipart/form-data' }
+            formData.append('model', 'whisper-1')
+
+            const apiKey = import.meta.env.VITE_OPENAI_API_KEY
+            if (!apiKey) throw new Error('Missing OpenAI API key')
+
+            const res = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${apiKey}`
+              },
+              body: formData
             })
-            if (res.data?.text) setTranscript(res.data.text)
+            const data = await res.json()
+            if (data?.text) setTranscript(data.text)
           } catch (err) {
             console.error('Whisper transcription failed', err)
           }


### PR DESCRIPTION
## Summary
- record audio and transcribe with OpenAI Whisper
- use ElevenLabs API directly for speech synthesis

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ff2407fd08326b1b947c4e9d03b2d