### PR TITLE
Add persistent message storage with summarization

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -1,15 +1,14 @@
-import React, { createContext, useContext, useState, useCallback } from 'react';
-import { Message } from '@/components/dashboard/ChatMessage';
+import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import type { ChatMessage } from '@/types/chat';
 import { sendChatMessage } from '@/api/chat';
 import { generateWidgets } from '@/api/widgets';
-import { useCharacter } from '@/hooks/useCharacter';
 import { useProjectStorage } from '@/hooks/useProjectStorage';
 import { AuraMemoryService } from '@/services/AuraMemoryService';
 
 type AuraState = 'idle' | 'listening' | 'thinking' | 'speaking';
 
 interface ChatContextType {
-  messages: Message[];
+  messages: ChatMessage[];
   activeWidgets: any[];
   auraState: AuraState;
   sendMessage: (content: string) => Promise<void>;
@@ -22,39 +21,41 @@ const ChatContext = createContext<ChatContextType | undefined>(undefined);
 export function ChatProvider({ children }: { children: React.ReactNode }) {
   const [auraState, setAuraState] = useState<AuraState>('idle');
   const { activeProject, updateProject } = useProjectStorage();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
 
-  // Get project-specific data
-  const messages = activeProject?.chatHistory || [];
   const activeWidgets = activeProject?.widgets || [];
+
+  useEffect(() => {
+    if (activeProject) {
+      AuraMemoryService.getConversation(activeProject.id).then(setMessages);
+    } else {
+      setMessages([]);
+    }
+  }, [activeProject]);
 
   const sendMessage = useCallback(async (content: string): Promise<string> => {
     if (!activeProject) return '';
 
-    const userMessage: Message = {
-      id: Date.now().toString(),
-      content,
+    const userMessage: ChatMessage = {
       sender: 'user',
-      timestamp: new Date()
+      text: content,
+      timestamp: new Date().toISOString()
     };
-
-    const updatedMessages = [...messages, userMessage];
-    await updateProject(activeProject.id, { chatHistory: updatedMessages });
+    await AuraMemoryService.addMessage(activeProject.id, userMessage);
+    setMessages(await AuraMemoryService.getConversation(activeProject.id));
     setAuraState('thinking');
 
     try {
       console.log('Sending message to Aura:', content);
       const response = await sendChatMessage(content);
 
-      const auraMessage: Message = {
-        id: (Date.now() + 1).toString(),
-        content: response.message,
+      const auraMessage: ChatMessage = {
         sender: 'aura',
-        timestamp: new Date()
+        text: response.message,
+        timestamp: new Date().toISOString()
       };
-
-      const finalMessages = [...updatedMessages, auraMessage];
-      await updateProject(activeProject.id, { chatHistory: finalMessages });
-      AuraMemoryService.persistSummary(activeProject.id);
+      await AuraMemoryService.addMessage(activeProject.id, auraMessage);
+      setMessages(await AuraMemoryService.getConversation(activeProject.id));
 
       // Generate new widgets based on the conversation context
       const widgetResponse = await generateWidgets(content, activeWidgets.map(w => w.id));
@@ -72,7 +73,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       setAuraState('idle');
       return '';
     }
-  }, [activeProject, messages, activeWidgets, updateProject]);
+  }, [activeProject, activeWidgets, updateProject]);
 
   const handleWidgetAction = useCallback(async (action: string, data?: any) => {
     if (!activeProject) return;

--- a/src/lib/electric.ts
+++ b/src/lib/electric.ts
@@ -1,5 +1,6 @@
 import Dexie, { Table } from 'dexie'
 import type { Project } from '@/types/project'
+import type { ChatMessage } from '@/types/chat'
 
 /**
  * Minimal ElectricSQL client using Dexie/IndexedDB for local storage.
@@ -8,14 +9,16 @@ import type { Project } from '@/types/project'
 class ElectricDatabase extends Dexie {
   projects!: Table<Project, string>
   summaries!: Table<{ id: string; summary: string; createdAt: string }, string>
+  messages!: Table<ChatMessage & { projectId: string }, number>
   settings!: Table<{ key: string; value: string }, string>
 
   constructor() {
     super('lifepilot-electric')
-    this.version(1).stores({
+    this.version(2).stores({
       projects: 'id',
       summaries: 'id, createdAt',
-      settings: 'key'
+      settings: 'key',
+      messages: '++id, projectId, timestamp'
     })
   }
 }

--- a/src/services/AuraMemoryService.ts
+++ b/src/services/AuraMemoryService.ts
@@ -1,45 +1,95 @@
 import { electric } from '@/lib/electric'
+import type { ChatMessage } from '@/types/chat'
 
 export class AuraMemoryService {
-  private static readonly STORAGE_KEY = 'aura_conversation'
+  private static readonly MEMORY_THRESHOLD = 20
 
-  /** add one message (user or aura) to end of the log */
-  static addMessage(message: { sender: 'user' | 'aura'; text: string; timestamp?: string }) {
-    const convo = this.getConversation()
-    convo.push({
-      ...message,
+  /** add one message to the project conversation */
+  static async addMessage(
+    projectId: string,
+    message: { sender: 'user' | 'aura'; text: string; timestamp?: string }
+  ) {
+    await electric.messages.add({
+      projectId,
+      sender: message.sender,
+      text: message.text,
       timestamp: message.timestamp ?? new Date().toISOString()
     })
-    this.saveConversation(convo)
+    await this.summarizeIfNeeded(projectId)
   }
 
-  /** get full array of all messages */
-  static getConversation(): Array<{ sender: string; text: string; timestamp: string }> {
-    try {
-      const raw = localStorage.getItem(this.STORAGE_KEY)
-      return raw ? JSON.parse(raw) : []
-    } catch {
-      return []
-    }
+  /** get full array of all messages for a project */
+  static async getConversation(projectId: string): Promise<ChatMessage[]> {
+    return await electric.messages
+      .where('projectId')
+      .equals(projectId)
+      .sortBy('timestamp')
   }
 
-  /** overwrite entire conversation */
-  private static saveConversation(convo: any[]) {
-    localStorage.setItem(this.STORAGE_KEY, JSON.stringify(convo))
-  }
-
-  /** completely wipe memory */
-  static clearConversation() {
-    localStorage.removeItem(this.STORAGE_KEY)
+  /** wipe conversation for a project */
+  static async clearConversation(projectId: string) {
+    await electric.messages.where('projectId').equals(projectId).delete()
   }
 
   /**
-   * Generate a simple text summary of the conversation and persist it
+   * Generate a text summary of the conversation and persist it
    * in the ElectricSQL summaries table using the provided project id.
    */
-  static persistSummary(projectId: string) {
-    const convo = this.getConversation()
-    const summary = convo.map(m => m.text).join(' ').slice(0, 200)
-    electric.summaries.put({ id: projectId, summary, createdAt: new Date().toISOString() })
+  static async persistSummary(projectId: string) {
+    const convo = await this.getConversation(projectId)
+    const summary = await this.generateSummary(convo)
+    await electric.summaries.put({
+      id: projectId,
+      summary,
+      createdAt: new Date().toISOString()
+    })
+  }
+
+  /** summarize old messages when over threshold */
+  private static async summarizeIfNeeded(projectId: string) {
+    const convo = await this.getConversation(projectId)
+    if (convo.length <= this.MEMORY_THRESHOLD) return
+
+    const excess = convo.length - this.MEMORY_THRESHOLD
+    const toSummarize = convo.slice(0, excess)
+    const summary = await this.generateSummary(toSummarize)
+    await electric.summaries.add({
+      id: crypto.randomUUID(),
+      summary,
+      createdAt: new Date().toISOString()
+    })
+    const ids = toSummarize.map((m: any) => m.id)
+    await electric.messages.bulkDelete(ids)
+  }
+
+  /** helper to call OpenAI to summarize text */
+  private static async generateSummary(messages: ChatMessage[]): Promise<string> {
+    const apiKey = import.meta.env.VITE_OPENAI_API_KEY
+    const prompt = messages
+      .map(m => `${m.sender}: ${m.text}`)
+      .join('\n')
+
+    if (!apiKey) {
+      return prompt.slice(0, 200)
+    }
+
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [{ role: 'user', content: `Summarize: \n${prompt}` }],
+          max_tokens: 150
+        })
+      })
+      const data = await res.json()
+      return data.choices?.[0]?.message?.content?.trim() ?? ''
+    } catch {
+      return prompt.slice(0, 200)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a `messages` table in the ElectricDB schema
- rework `AuraMemoryService` to use the messages table and summarize older entries via OpenAI
- update `ChatContext` to load and save messages per project

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ff250b5e083268b20495e36af6854