### PR TITLE
Use OpenAI for onboarding plans

### DIFF
--- a/src/api/ai.ts
+++ b/src/api/ai.ts
@@ -1,20 +1,52 @@
-import api from './api';
-
 // Description: Process onboarding responses with AI to create enhanced life plan or project plan
-// Endpoint: POST /ai/onboarding
-// Request: { responses: Record<string, any>, planType: 'life' | 'project' }
-// Response: { success: boolean, plan: any, message: string, usedFallback?: boolean }
+// Returns: { success: boolean, plan: any, message: string, usedFallback?: boolean }
 export const processOnboardingWithAI = async (responses: Record<string, any>, planType: 'life' | 'project') => {
+  console.log('AI API: Processing onboarding with AI', { planType, responseKeys: Object.keys(responses) });
+
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+  if (!apiKey) {
+    console.warn('AI API: Missing OpenAI API key');
+    return { success: false, plan: null, message: 'Missing OpenAI API key', usedFallback: true };
+  }
+
+  const prompt = `Using the following onboarding answers, create a structured ${planType} plan in JSON format.\n\n${JSON.stringify(responses)}`;
+
+  const body = {
+    model: 'gpt-3.5-turbo',
+    messages: [
+      { role: 'system', content: 'You are Aura, an AI assistant that generates concise and actionable plans.' },
+      { role: 'user', content: prompt }
+    ]
+  };
+
   try {
-    console.log('AI API: Processing onboarding with AI', { planType, responseKeys: Object.keys(responses) });
-    const response = await api.post('/ai/onboarding', {
-      responses,
-      planType
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify(body)
     });
-    console.log('AI API: Received AI-enhanced plan', response.data);
-    return response.data;
+
+    const data = await res.json();
+    console.log('AI API: OpenAI response:', JSON.stringify(data, null, 2));
+    const content = data.choices?.[0]?.message?.content?.trim() || '';
+
+    let plan: any = null;
+    try {
+      plan = JSON.parse(content);
+    } catch (parseError) {
+      console.error('AI API: Failed to parse plan JSON', parseError);
+    }
+
+    if (plan) {
+      return { success: true, plan, message: 'AI-enhanced plan created' };
+    }
+
+    return { success: false, plan: null, message: 'Invalid AI response', usedFallback: true };
   } catch (error: any) {
-    console.error('AI API: Error processing onboarding:', error);
-    throw new Error(error?.response?.data?.message || error.message);
+    console.error('AI API: Error calling OpenAI:', error);
+    return { success: false, plan: null, message: error.message || 'Network error', usedFallback: true };
   }
 };


### PR DESCRIPTION
## Summary
- call OpenAI directly when creating onboarding plans
- build a prompt from onboarding responses
- parse JSON plan and handle failures gracefully

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688003d3f5648326bb267dc64a9ed957