### PR TITLE
Extend ElectricSQL sync for more tables

### DIFF
--- a/src/hooks/useElectricSync.ts
+++ b/src/hooks/useElectricSync.ts
@@ -2,6 +2,18 @@ import { useEffect } from 'react'
 import { ShapeStream, isChangeMessage } from '@electric-sql/client'
 import { electric } from '@/lib/electric'
 import type { Project } from '@/types/project'
+import type { ChatMessage } from '@/types/chat'
+
+interface MessageRow extends ChatMessage {
+  id: number
+  projectId: string
+}
+
+interface SummaryRow {
+  id: string
+  summary: string
+  createdAt: string
+}
 
 /**
  * Hook that syncs local ElectricSQL tables with the backend when the browser
@@ -9,27 +21,28 @@ import type { Project } from '@/types/project'
  */
 export function useElectricSync() {
   useEffect(() => {
-    let stream: ShapeStream<Project> | null = null
+    let projectStream: ShapeStream<Project> | null = null
+    let messageStream: ShapeStream<MessageRow> | null = null
+    let summaryStream: ShapeStream<SummaryRow> | null = null
 
-    const startSync = async () => {
+    const startProjects = async () => {
       if (!navigator.onLine) return
-
-      if (stream?.isConnected()) return
+      if (projectStream?.isConnected()) return
 
       try {
-        stream = new ShapeStream<Project>({
+        projectStream = new ShapeStream<Project>({
           url: `${import.meta.env.VITE_ELECTRIC_URL}/v1/shape`,
           params: { table: 'projects', replica: 'full' },
           subscribe: true,
           onError: async err => {
-            console.error('[electric] sync error', err)
-            stream?.unsubscribeAll()
-            stream = null
-            if (navigator.onLine) setTimeout(startSync, 5000)
+            console.error('[electric] project sync error', err)
+            projectStream?.unsubscribeAll()
+            projectStream = null
+            if (navigator.onLine) setTimeout(startProjects, 5000)
           }
         })
 
-        stream.subscribe(async messages => {
+        projectStream.subscribe(async messages => {
           for (const msg of messages) {
             if (isChangeMessage<Project>(msg)) {
               const { operation } = msg.headers
@@ -43,16 +56,97 @@ export function useElectricSync() {
           }
         })
       } catch (err) {
-        console.error('[electric] failed to start sync', err)
-        if (navigator.onLine) setTimeout(startSync, 5000)
+        console.error('[electric] failed to start project sync', err)
+        if (navigator.onLine) setTimeout(startProjects, 5000)
       }
     }
 
-    window.addEventListener('online', startSync)
-    startSync()
+    const startMessages = async () => {
+      if (!navigator.onLine) return
+      if (messageStream?.isConnected()) return
+
+      try {
+        messageStream = new ShapeStream<MessageRow>({
+          url: `${import.meta.env.VITE_ELECTRIC_URL}/v1/shape`,
+          params: { table: 'messages', replica: 'full' },
+          subscribe: true,
+          onError: async err => {
+            console.error('[electric] message sync error', err)
+            messageStream?.unsubscribeAll()
+            messageStream = null
+            if (navigator.onLine) setTimeout(startMessages, 5000)
+          }
+        })
+
+        messageStream.subscribe(async messages => {
+          for (const msg of messages) {
+            if (isChangeMessage<MessageRow>(msg)) {
+              const { operation } = msg.headers
+              const row = msg.value as MessageRow
+              if (operation === 'insert' || operation === 'update') {
+                await electric.messages.put(row)
+              } else if (operation === 'delete') {
+                await electric.messages.delete(row.id)
+              }
+            }
+          }
+        })
+      } catch (err) {
+        console.error('[electric] failed to start message sync', err)
+        if (navigator.onLine) setTimeout(startMessages, 5000)
+      }
+    }
+
+    const startSummaries = async () => {
+      if (!navigator.onLine) return
+      if (summaryStream?.isConnected()) return
+
+      try {
+        summaryStream = new ShapeStream<SummaryRow>({
+          url: `${import.meta.env.VITE_ELECTRIC_URL}/v1/shape`,
+          params: { table: 'summaries', replica: 'full' },
+          subscribe: true,
+          onError: async err => {
+            console.error('[electric] summary sync error', err)
+            summaryStream?.unsubscribeAll()
+            summaryStream = null
+            if (navigator.onLine) setTimeout(startSummaries, 5000)
+          }
+        })
+
+        summaryStream.subscribe(async messages => {
+          for (const msg of messages) {
+            if (isChangeMessage<SummaryRow>(msg)) {
+              const { operation } = msg.headers
+              const row = msg.value as SummaryRow
+              if (operation === 'insert' || operation === 'update') {
+                await electric.summaries.put(row)
+              } else if (operation === 'delete') {
+                await electric.summaries.delete(row.id)
+              }
+            }
+          }
+        })
+      } catch (err) {
+        console.error('[electric] failed to start summary sync', err)
+        if (navigator.onLine) setTimeout(startSummaries, 5000)
+      }
+    }
+
+    const startAll = () => {
+      startProjects()
+      startMessages()
+      startSummaries()
+    }
+
+    window.addEventListener('online', startAll)
+    startAll()
+
     return () => {
-      window.removeEventListener('online', startSync)
-      stream?.unsubscribeAll()
+      window.removeEventListener('online', startAll)
+      projectStream?.unsubscribeAll()
+      messageStream?.unsubscribeAll()
+      summaryStream?.unsubscribeAll()
     }
   }, [])
 }


### PR DESCRIPTION
## Summary
- sync ElectricSQL `messages` and `summaries` tables in addition to `projects`
- reconnect all streams on failure and when browser comes back online

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688004c8e0d483268ceab991d8b6cd02