### PR TITLE
Add proactive tips scheduler

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -14,6 +14,8 @@ interface ChatContextType {
   sendMessage: (content: string) => Promise<void>;
   setAuraState: (state: AuraState) => void;
   handleWidgetAction: (action: string, data?: any) => void;
+  proactiveTips: string[];
+  refreshProactiveTips: () => Promise<void>;
 }
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
@@ -22,15 +24,24 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const [auraState, setAuraState] = useState<AuraState>('idle');
   const { activeProject, updateProject } = useProjectStorage();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [proactiveTips, setProactiveTips] = useState<string[]>([]);
 
   const activeWidgets = activeProject?.widgets || [];
 
   useEffect(() => {
     if (activeProject) {
       AuraMemoryService.getConversation(activeProject.id).then(setMessages);
+      AuraMemoryService.getProactiveTips(activeProject.id).then(tips =>
+        setProactiveTips(tips.map(t => t.tip))
+      );
+      AuraMemoryService.startTipScheduler(activeProject.id);
     } else {
       setMessages([]);
+      setProactiveTips([]);
     }
+    return () => {
+      if (activeProject) AuraMemoryService.stopTipScheduler(activeProject.id);
+    };
   }, [activeProject]);
 
   const sendMessage = useCallback(async (content: string): Promise<string> => {
@@ -75,6 +86,12 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     }
   }, [activeProject, activeWidgets, updateProject]);
 
+  const refreshProactiveTips = useCallback(async () => {
+    if (!activeProject) return;
+    const tips = await AuraMemoryService.getProactiveTips(activeProject.id);
+    setProactiveTips(tips.map(t => t.tip));
+  }, [activeProject]);
+
   const handleWidgetAction = useCallback(async (action: string, data?: any) => {
     if (!activeProject) return;
 
@@ -111,7 +128,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       auraState,
       sendMessage,
       setAuraState,
-      handleWidgetAction
+      handleWidgetAction,
+      proactiveTips,
+      refreshProactiveTips
     }}>
       {children}
     </ChatContext.Provider>

--- a/src/hooks/useElectricSync.ts
+++ b/src/hooks/useElectricSync.ts
@@ -15,6 +15,13 @@ interface SummaryRow {
   createdAt: string
 }
 
+interface TipRow {
+  id: string
+  projectId: string
+  tip: string
+  createdAt: string
+}
+
 /**
  * Hook that syncs local ElectricSQL tables with the backend when the browser
  * comes online using the official client utilities.
@@ -24,6 +31,7 @@ export function useElectricSync() {
     let projectStream: ShapeStream<Project> | null = null
     let messageStream: ShapeStream<MessageRow> | null = null
     let summaryStream: ShapeStream<SummaryRow> | null = null
+    let tipStream: ShapeStream<TipRow> | null = null
 
     const startProjects = async () => {
       if (!navigator.onLine) return
@@ -133,10 +141,47 @@ export function useElectricSync() {
       }
     }
 
+    const startTips = async () => {
+      if (!navigator.onLine) return
+      if (tipStream?.isConnected()) return
+
+      try {
+        tipStream = new ShapeStream<TipRow>({
+          url: `${import.meta.env.VITE_ELECTRIC_URL}/v1/shape`,
+          params: { table: 'tips', replica: 'full' },
+          subscribe: true,
+          onError: async err => {
+            console.error('[electric] tip sync error', err)
+            tipStream?.unsubscribeAll()
+            tipStream = null
+            if (navigator.onLine) setTimeout(startTips, 5000)
+          }
+        })
+
+        tipStream.subscribe(async messages => {
+          for (const msg of messages) {
+            if (isChangeMessage<TipRow>(msg)) {
+              const { operation } = msg.headers
+              const row = msg.value as TipRow
+              if (operation === 'insert' || operation === 'update') {
+                await electric.tips.put(row)
+              } else if (operation === 'delete') {
+                await electric.tips.delete(row.id)
+              }
+            }
+          }
+        })
+      } catch (err) {
+        console.error('[electric] failed to start tip sync', err)
+        if (navigator.onLine) setTimeout(startTips, 5000)
+      }
+    }
+
     const startAll = () => {
       startProjects()
       startMessages()
       startSummaries()
+      startTips()
     }
 
     window.addEventListener('online', startAll)
@@ -147,6 +192,7 @@ export function useElectricSync() {
       projectStream?.unsubscribeAll()
       messageStream?.unsubscribeAll()
       summaryStream?.unsubscribeAll()
+      tipStream?.unsubscribeAll()
     }
   }, [])
 }

--- a/src/lib/electric.ts
+++ b/src/lib/electric.ts
@@ -11,14 +11,16 @@ class ElectricDatabase extends Dexie {
   summaries!: Table<{ id: string; summary: string; createdAt: string }, string>
   messages!: Table<ChatMessage & { projectId: string }, number>
   settings!: Table<{ key: string; value: string }, string>
+  tips!: Table<{ id: string; projectId: string; tip: string; createdAt: string }, string>
 
   constructor() {
     super('lifepilot-electric')
-    this.version(2).stores({
+    this.version(3).stores({
       projects: 'id',
       summaries: 'id, createdAt',
       settings: 'key',
-      messages: '++id, projectId, timestamp'
+      messages: '++id, projectId, timestamp',
+      tips: 'id, projectId, createdAt'
     })
   }
 }

--- a/src/services/AuraMemoryService.ts
+++ b/src/services/AuraMemoryService.ts
@@ -1,8 +1,16 @@
 import { electric } from '@/lib/electric'
 import type { ChatMessage } from '@/types/chat'
 
+interface ProactiveTip {
+  id: string
+  projectId: string
+  tip: string
+  createdAt: string
+}
+
 export class AuraMemoryService {
   private static readonly MEMORY_THRESHOLD = 20
+  private static reviewIntervals: Record<string, any> = {}
 
   /** add one message to the project conversation */
   static async addMessage(
@@ -62,6 +70,49 @@ export class AuraMemoryService {
     await electric.messages.bulkDelete(ids)
   }
 
+  /** start periodic review of conversation summaries */
+  static startTipScheduler(projectId: string, intervalMs = 1000 * 60 * 30) {
+    if (this.reviewIntervals[projectId]) return
+    this.reviewIntervals[projectId] = setInterval(
+      () => this.reviewAndStoreTip(projectId),
+      intervalMs
+    )
+    // run an immediate review on start
+    this.reviewAndStoreTip(projectId)
+  }
+
+  /** stop the periodic review */
+  static stopTipScheduler(projectId: string) {
+    const handle = this.reviewIntervals[projectId]
+    if (handle) {
+      clearInterval(handle)
+      delete this.reviewIntervals[projectId]
+    }
+  }
+
+  /** fetch stored proactive tips */
+  static async getProactiveTips(projectId: string): Promise<ProactiveTip[]> {
+    return await electric.tips
+      .where('projectId')
+      .equals(projectId)
+      .sortBy('createdAt')
+  }
+
+  /** review summaries and store a tip */
+  private static async reviewAndStoreTip(projectId: string) {
+    const convo = await this.getConversation(projectId)
+    if (convo.length === 0) return
+    const summary = await this.generateSummary(convo)
+    const tip = await this.generateTip(summary)
+    if (!tip) return
+    await electric.tips.add({
+      id: crypto.randomUUID(),
+      projectId,
+      tip,
+      createdAt: new Date().toISOString()
+    })
+  }
+
   /** helper to call OpenAI to summarize text */
   private static async generateSummary(messages: ChatMessage[]): Promise<string> {
     const apiKey = import.meta.env.VITE_OPENAI_API_KEY
@@ -90,6 +141,36 @@ export class AuraMemoryService {
       return data.choices?.[0]?.message?.content?.trim() ?? ''
     } catch {
       return prompt.slice(0, 200)
+    }
+  }
+
+  /** call OpenAI to create a short suggestion based on a summary */
+  private static async generateTip(summary: string): Promise<string> {
+    const apiKey = import.meta.env.VITE_OPENAI_API_KEY
+    if (!apiKey) return ''
+
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [
+            {
+              role: 'user',
+              content: `Based on this conversation summary, give a short actionable suggestion or reminder in one sentence: \n${summary}`
+            }
+          ],
+          max_tokens: 60
+        })
+      })
+      const data = await res.json()
+      return data.choices?.[0]?.message?.content?.trim() ?? ''
+    } catch {
+      return ''
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `tips` table to ElectricDB
- sync tips via ElectricSQL hook
- create periodic suggestion scheduler in `AuraMemoryService`
- expose tip retrieval in chat context

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68800bbd829c8326abee16d6905ac76e