### PR TITLE
Suppress console logs in production

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,11 @@ import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
+// Suppress console.log statements in production builds
+if (import.meta.env.PROD) {
+  console.log = () => {};
+}
+
 console.log('[Main] Starting React application...');
 console.log('[Main] Environment variables:', {
   NODE_ENV: import.meta.env.NODE_ENV,


### PR DESCRIPTION
## Summary
- disable console.log when running production builds

## Testing
- `npm run build`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68800c4cb5788326b5ef73aa1f27683f