### PR TITLE
Define explicit chat interfaces

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -4,7 +4,9 @@ import brain from '@/brain/Brain';
  * Send a chat message directly to OpenAI using the configured brain prompts.
  * Returns the assistant's reply wrapped in an object with a `message` field.
  */
-export const sendChatMessage = async (message: string, context?: any) => {
+import type { ChatContext } from '@/types/chat';
+
+export const sendChatMessage = async (message: string, context?: ChatContext) => {
   console.log('sendChatMessage - Called with message:', message);
   console.log('sendChatMessage - Context:', context);
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -6,18 +6,37 @@ export interface ChatMessage {
   timestamp: string;
 }
 
+export interface ChatHistoryEntry {
+  id: string;
+  sender: 'user' | 'aura';
+  content: string;
+  timestamp?: string;
+}
+
 // API response types for chat endpoints
 export interface ChatApiResponse {
   success: boolean;
   response: string;
-  context?: any;
+  context?: ChatContext;
 }
 
 // Chat context for maintaining conversation state
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export interface ChatContextMetadata {
+  [key: string]: JsonValue;
+}
+
 export interface ChatContext {
   projectId?: string;
   conversationId?: string;
-  metadata?: Record<string, any>;
+  metadata?: ChatContextMetadata;
 }
 
 // Chat request payload

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,3 +1,6 @@
+import type { ChatHistoryEntry } from './chat';
+import type { Widget } from './widget';
+
 export interface Project {
   id: string;
   name: string;
@@ -18,8 +21,8 @@ export interface Project {
     jobPerk: string;
   };
   milestones: ProjectMilestone[];
-  widgets: any[];
-  chatHistory: any[];
+  widgets: Widget[];
+  chatHistory: ChatHistoryEntry[];
 }
 
 export interface ProjectMilestone {

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -1,0 +1,34 @@
+export type WidgetType =
+  | 'chart'
+  | 'progress'
+  | 'list'
+  | 'metric'
+  | 'calendar'
+  | 'board'
+  | 'project'
+  | 'analytics';
+
+export interface WidgetAction {
+  label: string;
+  action: string;
+}
+
+export interface WidgetConfig {
+  colors?: string[];
+  showProgress?: boolean;
+  interactive?: boolean;
+  height?: number;
+  actions?: WidgetAction[];
+}
+
+export interface Widget<T = Record<string, unknown>> {
+  id: string;
+  type: WidgetType;
+  title: string;
+  icon?: string;
+  data: T[];
+  boardType?: 'project' | 'habit' | 'skill' | 'mood' | 'vision' | 'reading' | 'focus';
+  chartType?: 'pie' | 'line' | 'radar' | 'bar';
+  config?: WidgetConfig;
+}
+


### PR DESCRIPTION
## Summary
- tighten chat types by defining `ChatHistoryEntry` and `ChatContextMetadata`
- introduce reusable `Widget` types
- make project widgets and chat history strongly typed
- accept typed context in chat API helper

## Testing
- `npm ci`
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: numerous existing type errors)*
- `npx tsc --noEmit src/types/chat.ts src/types/project.ts src/types/widget.ts`

------
https://chatgpt.com/codex/tasks/task_e_68800c4f91788326a18fa993244ac5e4