### PR TITLE
Fix onboarding project creation

### DIFF
--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -28,8 +28,8 @@ export function Onboarding() {
     }
   };
 
-  const finish = () => {
-    createProject({
+  const finish = async () => {
+    await createProject({
       name: 'My LifePlan',
       icon: '🌟',
       category: 'personal',


### PR DESCRIPTION
## Summary
- wait for `createProject` in onboarding flow before navigating to dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880dfb972b083269d9d959f3e89ebe7