### PR TITLE
Add proactive tips toast

### DIFF
--- a/src/components/dashboard/AuraLayout.tsx
+++ b/src/components/dashboard/AuraLayout.tsx
@@ -12,6 +12,7 @@ import { GoalsModal } from './modals/GoalsModal';
 import { TasksModal } from './modals/TasksModal';
 import { RewardsModal } from './modals/RewardsModal';
 import { ChatProvider, useChatContext } from '@/contexts/ChatContext';
+import { ProactiveTipsToast } from './ProactiveTipsToast';
 import { CharacterSheet } from '@/components/rpg/CharacterSheet';
 import { RoadmapTimeline } from '@/components/rpg/RoadmapTimeline';
 import { QuestLog } from '@/components/rpg/QuestLog';
@@ -505,6 +506,7 @@ export function AuraLayout() {
   return (
     <ChatProvider>
       <AuraLayoutContent />
+      <ProactiveTipsToast />
     </ChatProvider>
   );
 }

--- a/src/components/dashboard/ProactiveTipsToast.tsx
+++ b/src/components/dashboard/ProactiveTipsToast.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { useChatContext } from '@/contexts/ChatContext';
+import { toast } from '@/hooks/useToast';
+import { Button } from '@/components/ui/button';
+
+export function ProactiveTipsToast() {
+  const { proactiveTips, refreshProactiveTips } = useChatContext();
+  const prevCountRef = useRef(proactiveTips.length);
+
+  useEffect(() => {
+    if (proactiveTips.length > prevCountRef.current) {
+      const newTips = proactiveTips.slice(prevCountRef.current);
+      newTips.forEach((tip) =>
+        toast({
+          title: 'Proactive Tip',
+          description: tip
+        })
+      );
+      prevCountRef.current = proactiveTips.length;
+    }
+  }, [proactiveTips]);
+
+  const handleRefresh = async () => {
+    await refreshProactiveTips();
+  };
+
+  return (
+    <Button
+      onClick={handleRefresh}
+      size="icon"
+      variant="ghost"
+      className="fixed bottom-4 right-4 z-[1001]"
+      aria-label="Refresh Tips"
+    >
+      <RefreshCw className="w-5 h-5" />
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- show toast notifications for proactive tips
- include tips toast across dashboard layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880dfec4ff88326bcf6d91a3ddf7c4a