### PR TITLE
Implement editable brain settings

### DIFF
--- a/src/hooks/useElectricSync.ts
+++ b/src/hooks/useElectricSync.ts
@@ -22,6 +22,11 @@ interface TipRow {
   createdAt: string
 }
 
+interface BrainSettingsRow {
+  key: string
+  value: string
+}
+
 /**
  * Hook that syncs local ElectricSQL tables with the backend when the browser
  * comes online using the official client utilities.
@@ -30,8 +35,9 @@ export function useElectricSync() {
   useEffect(() => {
     let projectStream: ShapeStream<Project> | null = null
     let messageStream: ShapeStream<MessageRow> | null = null
-    let summaryStream: ShapeStream<SummaryRow> | null = null
-    let tipStream: ShapeStream<TipRow> | null = null
+  let summaryStream: ShapeStream<SummaryRow> | null = null
+  let tipStream: ShapeStream<TipRow> | null = null
+  let brainStream: ShapeStream<BrainSettingsRow> | null = null
 
     const startProjects = async () => {
       if (!navigator.onLine) return
@@ -141,7 +147,7 @@ export function useElectricSync() {
       }
     }
 
-    const startTips = async () => {
+  const startTips = async () => {
       if (!navigator.onLine) return
       if (tipStream?.isConnected()) return
 
@@ -167,8 +173,44 @@ export function useElectricSync() {
                 await electric.tips.put(row)
               } else if (operation === 'delete') {
                 await electric.tips.delete(row.id)
+    }
+  }
+
+    const startBrainSettings = async () => {
+      if (!navigator.onLine) return
+      if (brainStream?.isConnected()) return
+
+      try {
+        brainStream = new ShapeStream<BrainSettingsRow>({
+          url: `${import.meta.env.VITE_ELECTRIC_URL}/v1/shape`,
+          params: { table: 'brain_settings', replica: 'full' },
+          subscribe: true,
+          onError: async err => {
+            console.error('[electric] brain settings sync error', err)
+            brainStream?.unsubscribeAll()
+            brainStream = null
+            if (navigator.onLine) setTimeout(startBrainSettings, 5000)
+          }
+        })
+
+        brainStream.subscribe(async messages => {
+          for (const msg of messages) {
+            if (isChangeMessage<BrainSettingsRow>(msg)) {
+              const { operation } = msg.headers
+              const row = msg.value as BrainSettingsRow
+              if (operation === 'insert' || operation === 'update') {
+                await electric.brain_settings.put(row)
+              } else if (operation === 'delete') {
+                await electric.brain_settings.delete(row.key)
               }
             }
+          }
+        })
+      } catch (err) {
+        console.error('[electric] failed to start brain settings sync', err)
+        if (navigator.onLine) setTimeout(startBrainSettings, 5000)
+      }
+    }
           }
         })
       } catch (err) {
@@ -182,6 +224,7 @@ export function useElectricSync() {
       startMessages()
       startSummaries()
       startTips()
+      startBrainSettings()
     }
 
     window.addEventListener('online', startAll)
@@ -193,6 +236,7 @@ export function useElectricSync() {
       messageStream?.unsubscribeAll()
       summaryStream?.unsubscribeAll()
       tipStream?.unsubscribeAll()
+      brainStream?.unsubscribeAll()
     }
   }, [])
 }

--- a/src/lib/electric.ts
+++ b/src/lib/electric.ts
@@ -11,14 +11,16 @@ class ElectricDatabase extends Dexie {
   summaries!: Table<{ id: string; summary: string; createdAt: string }, string>
   messages!: Table<ChatMessage & { projectId: string }, number>
   settings!: Table<{ key: string; value: string }, string>
+  brain_settings!: Table<{ key: string; value: string }, string>
   tips!: Table<{ id: string; projectId: string; tip: string; createdAt: string }, string>
 
   constructor() {
     super('lifepilot-electric')
-    this.version(3).stores({
+    this.version(4).stores({
       projects: 'id',
       summaries: 'id, createdAt',
       settings: 'key',
+      brain_settings: 'key',
       messages: '++id, projectId, timestamp',
       tips: 'id, projectId, createdAt'
     })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { loadBrainSettings } from './services/BrainSettingsService'
 
 // Suppress console.log statements in production builds
 if (import.meta.env.PROD) {
@@ -39,18 +40,23 @@ window.addEventListener('unhandledrejection', (event) => {
   console.error('[Main] Rejection reason:', event.reason);
 });
 
-try {
-  console.log('[Main] Creating React root...');
-  const root = ReactDOM.createRoot(document.getElementById('root')!);
-  console.log('[Main] Root created successfully');
-  
-  console.log('[Main] Rendering App component...');
-  root.render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-  );
-  console.log('[Main] App component rendered successfully');
-} catch (error) {
-  console.error('[Main] Error during React initialization:', error);
+async function start() {
+  try {
+    await loadBrainSettings()
+    console.log('[Main] Creating React root...')
+    const root = ReactDOM.createRoot(document.getElementById('root')!)
+    console.log('[Main] Root created successfully')
+
+    console.log('[Main] Rendering App component...')
+    root.render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>,
+    )
+    console.log('[Main] App component rendered successfully')
+  } catch (error) {
+    console.error('[Main] Error during React initialization:', error)
+  }
 }
+
+start()

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -5,6 +5,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  exportBrainSettings,
+  importBrainSettings,
+  saveBrainSettings,
+  BrainSettingsData,
+} from '@/services/BrainSettingsService';
 
 export function SettingsPage() {
   const [voiceEnabled, setVoiceEnabled] = useState<boolean>(false);
@@ -12,13 +19,40 @@ export function SettingsPage() {
   const [apiKey, setApiKey] = useState('');
   const [syncStatus, setSyncStatus] = useState('disconnected');
 
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [contextPrompt, setContextPrompt] = useState('');
+  const [behaviorStyle, setBehaviorStyle] = useState('');
+  const [filtersText, setFiltersText] = useState('[]');
+  const [skillsText, setSkillsText] = useState('[]');
+
   useEffect(() => {
     const storedKey = localStorage.getItem('lifepilot_api_key');
     if (storedKey) setApiKey(storedKey);
+    const load = async () => {
+      const json = await exportBrainSettings();
+      try {
+        const data: BrainSettingsData = JSON.parse(json);
+        setSystemPrompt(data.cognition.systemPrompt || '');
+        setContextPrompt(data.cognition.contextPrompt || '');
+        setBehaviorStyle(data.behavior.style || '');
+        setFiltersText(JSON.stringify(data.filters, null, 2));
+        setSkillsText(JSON.stringify(data.skills, null, 2));
+      } catch (err) {
+        console.error('Failed to load brain settings', err);
+      }
+    };
+    load();
   }, []);
 
   const saveSettings = () => {
     localStorage.setItem('lifepilot_api_key', apiKey);
+    const data: BrainSettingsData = {
+      cognition: { systemPrompt, contextPrompt },
+      behavior: { style: behaviorStyle },
+      filters: JSON.parse(filtersText || '[]'),
+      skills: JSON.parse(skillsText || '[]'),
+    };
+    saveBrainSettings(data);
   };
 
   return (
@@ -58,6 +92,50 @@ export function SettingsPage() {
           <div className="space-y-2">
             <Label>ElectricSQL Sync Status</Label>
             <p className="text-sm text-muted-foreground">{syncStatus}</p>
+          </div>
+          <div className="space-y-2">
+            <Label>System Prompt</Label>
+            <Textarea value={systemPrompt} onChange={e => setSystemPrompt(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label>Context Prompt</Label>
+            <Textarea value={contextPrompt} onChange={e => setContextPrompt(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label>Behavior Style</Label>
+            <Input value={behaviorStyle} onChange={e => setBehaviorStyle(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label>Filters (array of function strings)</Label>
+            <Textarea value={filtersText} onChange={e => setFiltersText(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label>Skills (JSON array)</Label>
+            <Textarea value={skillsText} onChange={e => setSkillsText(e.target.value)} />
+          </div>
+          <div className="flex space-x-2">
+            <Button type="button" onClick={async () => {
+              const json = await exportBrainSettings();
+              const blob = new Blob([json], { type: 'application/json' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = 'brain_settings.json';
+              a.click();
+              URL.revokeObjectURL(url);
+            }}>Export</Button>
+            <Input type="file" accept="application/json" onChange={async e => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              const text = await file.text();
+              await importBrainSettings(text);
+              const data: BrainSettingsData = JSON.parse(text);
+              setSystemPrompt(data.cognition.systemPrompt || '');
+              setContextPrompt(data.cognition.contextPrompt || '');
+              setBehaviorStyle(data.behavior.style || '');
+              setFiltersText(JSON.stringify(data.filters, null, 2));
+              setSkillsText(JSON.stringify(data.skills, null, 2));
+            }} />
           </div>
           <Button onClick={saveSettings}>Save</Button>
         </CardContent>

--- a/src/services/BrainSettingsService.ts
+++ b/src/services/BrainSettingsService.ts
@@ -1,0 +1,63 @@
+import brain from '@/brain/Brain'
+import type { CognitionConfig } from '@/brain/cognition'
+import type { BehaviorConfig } from '@/brain/behavior'
+import type { Skill } from '@/brain/skills'
+import { electric } from '@/lib/electric'
+
+export interface BrainSettingsData {
+  cognition: CognitionConfig
+  behavior: BehaviorConfig
+  filters: string[]
+  skills: Skill[]
+}
+
+const STORAGE_KEY = 'config'
+
+function applyConfig(data: BrainSettingsData) {
+  brain.cognition.systemPrompt = data.cognition.systemPrompt
+  brain.cognition.contextPrompt = data.cognition.contextPrompt
+  brain.behavior.style = data.behavior.style
+  brain.filters = data.filters.map(code => {
+    try {
+      // eslint-disable-next-line no-new-func
+      return eval(`(${code})`) as (text: string) => string
+    } catch {
+      return (t: string) => t
+    }
+  })
+  brain.skills = data.skills
+}
+
+export async function loadBrainSettings() {
+  const row = await electric.brain_settings.get(STORAGE_KEY)
+  if (row?.value) {
+    try {
+      const data: BrainSettingsData = JSON.parse(row.value)
+      applyConfig(data)
+    } catch (err) {
+      console.error('Failed to parse brain settings', err)
+    }
+  }
+}
+
+export async function saveBrainSettings(data: BrainSettingsData) {
+  await electric.brain_settings.put({ key: STORAGE_KEY, value: JSON.stringify(data) })
+  applyConfig(data)
+}
+
+export async function exportBrainSettings(): Promise<string> {
+  const row = await electric.brain_settings.get(STORAGE_KEY)
+  if (row?.value) return row.value
+  const defaults: BrainSettingsData = {
+    cognition: brain.cognition,
+    behavior: brain.behavior,
+    filters: brain.filters.map(fn => fn.toString()),
+    skills: brain.skills
+  }
+  return JSON.stringify(defaults)
+}
+
+export async function importBrainSettings(json: string) {
+  const data: BrainSettingsData = JSON.parse(json)
+  await saveBrainSettings(data)
+}


### PR DESCRIPTION
## Summary
- allow customizing the AI brain configuration
- persist brain settings in a new `brain_settings` ElectricSQL table
- sync brain settings with the backend when online
- load stored settings during app startup
- add export/import and editing controls on the Settings page

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6880e50457888326b66da3ba0afdc92f