### PR TITLE
Add ElectricSQL URL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 VITE_API_BASE_URL=http://localhost:3000
 VITE_OPENAI_API_KEY=
 VITE_ELEVENLABS_API_KEY=
+VITE_ELECTRIC_URL=http://localhost:5133
 
 # Firebase configuration
 VITE_FIREBASE_API_KEY=AIzaSyBSI9AglDqMLmK2-ixZ_viTVRDaxnwbVvI

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Firebase values are required for authentication to work correctly.
 - `VITE_API_BASE_URL` – base URL of the remote API
 - `VITE_OPENAI_API_KEY` – OpenAI key used by the browser (optional)
 - `VITE_ELEVENLABS_API_KEY` – ElevenLabs key for voice features (optional)
+- `VITE_ELECTRIC_URL` – URL of the ElectricSQL backend (optional)
 - `VITE_FIREBASE_API_KEY` – Firebase project API key
 - `VITE_FIREBASE_AUTH_DOMAIN` – Firebase auth domain
 - `VITE_FIREBASE_PROJECT_ID` – Firebase project ID

--- a/src/hooks/useElectricSync.ts
+++ b/src/hooks/useElectricSync.ts
@@ -28,6 +28,10 @@ interface TipRow {
  */
 export function useElectricSync() {
   useEffect(() => {
+    if (!import.meta.env.VITE_ELECTRIC_URL) {
+      console.warn('[electric] VITE_ELECTRIC_URL not defined; skipping sync')
+      return
+    }
     let projectStream: ShapeStream<Project> | null = null
     let messageStream: ShapeStream<MessageRow> | null = null
     let summaryStream: ShapeStream<SummaryRow> | null = null


### PR DESCRIPTION
## Summary
- document `VITE_ELECTRIC_URL` in `.env.example` and README
- skip ElectricSQL sync when `VITE_ELECTRIC_URL` isn't provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880e613c77c8326b3182201c8efdb09