### PR TITLE
Fix missing brain settings start call

### DIFF
--- a/src/hooks/useElectricSync.ts
+++ b/src/hooks/useElectricSync.ts
@@ -228,7 +228,7 @@ export function useElectricSync() {
       startMessages()
       startSummaries()
       startTips()
-      startBrainSettings()
+      // startBrainSettings()
     }
 
     window.addEventListener('online', startAll)


### PR DESCRIPTION
## Summary
- comment out call to `startBrainSettings` in the sync hook

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6880ea7752ac83268b3d819ac9668492