### PR TITLE
Implement onboarding message and admin user check

### DIFF
--- a/src/__tests__/voice.test.tsx
+++ b/src/__tests__/voice.test.tsx
@@ -16,6 +16,7 @@ class FakeRec {
   lang = ''
   interimResults = false
   constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     lastRec = this
   }
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,14 @@
 
-import { Bell, LogOut } from "lucide-react"
+import { LogOut, User } from "lucide-react"
 import { Button } from "./ui/button"
 import { ThemeToggle } from "./ui/theme-toggle"
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "./ui/dropdown-menu"
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
 import { useAuth } from "@/contexts/AuthContext"
 import { useNavigate } from "react-router-dom"
 
 export function Header() {
-  const { logout } = useAuth()
+  const { logout, isAuthenticated, user } = useAuth()
   const navigate = useNavigate()
   const handleLogout = () => {
     logout()
@@ -20,13 +22,33 @@ export function Header() {
           <Button variant="ghost" onClick={() => navigate('/onboarding')}>
             Onboarding
           </Button>
-          <Button variant="ghost" onClick={() => navigate('/settings')}>
-            Settings
-          </Button>
           <ThemeToggle />
-          <Button variant="ghost" size="icon" onClick={handleLogout}>
-            <LogOut className="h-5 w-5" />
-          </Button>
+          {isAuthenticated && user ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="relative h-8 w-8 rounded-full p-0">
+                  <Avatar className="h-8 w-8">
+                    <AvatarImage src="" alt="User Avatar" />
+                    <AvatarFallback className="bg-muted text-white">
+                      {user.email.charAt(0)}
+                    </AvatarFallback>
+                  </Avatar>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-56 bg-gray-900 border-gray-700" align="end" forceMount>
+                <DropdownMenuItem onClick={() => navigate('/settings')} className="hover:bg-gray-800 cursor-pointer">
+                  <User className="mr-2 h-4 w-4" />
+                  <span>Settings</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={handleLogout} className="hover:bg-gray-800 cursor-pointer text-red-400">
+                  <LogOut className="mr-2 h-4 w-4" />
+                  <span>Log out</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <Button variant="ghost" onClick={() => navigate('/login')}>Login</Button>
+          )}
         </div>
       </div>
     </header>

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -15,7 +15,7 @@ interface DashboardHeaderProps {
 }
 
 export function DashboardHeader({ onMenuToggle }: DashboardHeaderProps) {
-  const { logout } = useAuth();
+  const { logout, user } = useAuth();
   const navigate = useNavigate();
   const isMobile = useMobile();
   const { activeProject } = useProjectStorage();
@@ -117,6 +117,15 @@ export function DashboardHeader({ onMenuToggle }: DashboardHeaderProps) {
                 <Settings className="mr-2 h-4 w-4" />
                 <span>Settings</span>
               </DropdownMenuItem>
+              {user?.isAdmin && (
+                <DropdownMenuItem
+                  className="hover:bg-gray-800 cursor-pointer"
+                  onClick={() => navigate('/admin')}
+                >
+                  <Crown className="mr-2 h-4 w-4" />
+                  <span>Admin Tools</span>
+                </DropdownMenuItem>
+              )}
               <DropdownMenuSeparator className="bg-gray-700" />
               <DropdownMenuItem onClick={handleLogout} className="hover:bg-gray-800 cursor-pointer text-red-400">
                 <LogOut className="mr-2 h-4 w-4" />

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -14,6 +14,7 @@ type User = {
   unlockedSkills?: string[];
   createdAt?: string;
   lastLoginAt?: string;
+  isAdmin?: boolean;
 };
 
 type AuthContextType = {
@@ -52,7 +53,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // Set user data if provided in login response
         if (response.user) {
           console.log("AuthContext - Setting user data from login response:", response.user);
-          setUser(response.user);
+          const adminUser = {
+            ...response.user,
+            isAdmin: response.user.email === 'deandeanazulay@gmail.com'
+          };
+          setUser(adminUser);
         }
         
         setIsAuthenticated(true);

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -29,20 +29,37 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const activeWidgets = activeProject?.widgets || [];
 
   useEffect(() => {
-    if (activeProject) {
-      AuraMemoryService.getConversation(activeProject.id).then(setMessages);
-      AuraMemoryService.getProactiveTips(activeProject.id).then(tips =>
-        setProactiveTips(tips.map(t => t.tip))
-      );
-      AuraMemoryService.startTipScheduler(activeProject.id);
-    } else {
-      setMessages([]);
-      setProactiveTips([]);
+    const loadConversation = async () => {
+      if (!activeProject) {
+        setMessages([])
+        setProactiveTips([])
+        return
+      }
+
+      const convo = await AuraMemoryService.getConversation(activeProject.id)
+      if (convo.length === 0) {
+        const onboarding: ChatMessage = {
+          sender: 'aura',
+          text: "Let's build your system. First, tell me your Game — your mission.",
+          timestamp: new Date().toISOString()
+        }
+        await AuraMemoryService.addMessage(activeProject.id, onboarding)
+        setMessages([onboarding])
+      } else {
+        setMessages(convo)
+      }
+
+      const tips = await AuraMemoryService.getProactiveTips(activeProject.id)
+      setProactiveTips(tips.map(t => t.tip))
+      AuraMemoryService.startTipScheduler(activeProject.id)
     }
+
+    loadConversation()
+
     return () => {
-      if (activeProject) AuraMemoryService.stopTipScheduler(activeProject.id);
-    };
-  }, [activeProject]);
+      if (activeProject) AuraMemoryService.stopTipScheduler(activeProject.id)
+    }
+  }, [activeProject])
 
   const sendMessage = useCallback(async (content: string): Promise<string> => {
     if (!activeProject) return '';


### PR DESCRIPTION
## Summary
- greet new users with an onboarding prompt when opening chat
- detect admin by email and flag on login
- expose admin tools in the dashboard menu
- show avatar dropdown in the site header
- silence a test lint error

## Testing
- `npm install`
- `npm test`
- `npm run type-check`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_6880fe144dcc83269d34b682ec2ce71c