### PR TITLE
refactor: eliminate eval in brain settings

### DIFF
--- a/src/__tests__/brainSettings.test.ts
+++ b/src/__tests__/brainSettings.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+let store: Record<string, string> = {}
+vi.mock('../lib/electric', () => ({
+  electric: {
+    brain_settings: {
+      get: vi.fn((key: string) => Promise.resolve(store[key] ? { key, value: store[key] } : undefined)),
+      put: vi.fn(({ key, value }: { key: string; value: string }) => { store[key] = value; return Promise.resolve() })
+    }
+  }
+}))
+
+import brain from '../brain/Brain'
+
+beforeEach(() => { store = {} })
+
+describe('BrainSettingsService', () => {
+  it('exports and imports settings', async () => {
+    const service = await import('../services/BrainSettingsService')
+    const data = {
+      cognition: { systemPrompt: 's', contextPrompt: '' },
+      behavior: { style: '' },
+      filters: ['trim', 'lowercase'],
+      skills: []
+    }
+    await service.saveBrainSettings(data)
+    const exported = await service.exportBrainSettings()
+    expect(JSON.parse(exported).filters).toEqual(['trim', 'lowercase'])
+
+    brain.filters = []
+    await service.importBrainSettings(exported)
+    const result = brain.filters.reduce((msg, fn) => fn(msg), ' HI ')
+    expect(result).toBe('hi')
+  })
+})

--- a/src/brain/filters.ts
+++ b/src/brain/filters.ts
@@ -1,10 +1,27 @@
-export type Filter = (text: string) => string;
+export type Filter = (text: string) => string
+
+export const filterRegistry: Record<string, Filter> = {
+  trim: text => text.trim(),
+  lowercase: text => text.toLowerCase(),
+  uppercase: text => text.toUpperCase()
+}
+
+export type FilterName = keyof typeof filterRegistry
 
 /**
  * List of filters applied to every outgoing message.
  */
-export const filters: Filter[] = [
-  text => text.trim()
-];
+export const filters: Filter[] = [filterRegistry.trim]
 
-export default filters;
+export function getFilterByName(name: string): Filter | undefined {
+  return filterRegistry[name as FilterName]
+}
+
+export function getFilterName(fn: Filter): string | undefined {
+  for (const [name, filter] of Object.entries(filterRegistry)) {
+    if (filter === fn) return name
+  }
+  return undefined
+}
+
+export default filters

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -106,7 +106,7 @@ export function SettingsPage() {
             <Input value={behaviorStyle} onChange={e => setBehaviorStyle(e.target.value)} />
           </div>
           <div className="space-y-2">
-            <Label>Filters (array of function strings)</Label>
+            <Label>Filters (array of filter names)</Label>
             <Textarea value={filtersText} onChange={e => setFiltersText(e.target.value)} />
           </div>
           <div className="space-y-2">

--- a/src/services/BrainSettingsService.ts
+++ b/src/services/BrainSettingsService.ts
@@ -2,6 +2,7 @@ import brain from '@/brain/Brain'
 import type { CognitionConfig } from '@/brain/cognition'
 import type { BehaviorConfig } from '@/brain/behavior'
 import type { Skill } from '@/brain/skills'
+import { getFilterByName, getFilterName } from '@/brain/filters'
 import { electric } from '@/lib/electric'
 
 export interface BrainSettingsData {
@@ -17,14 +18,8 @@ function applyConfig(data: BrainSettingsData) {
   brain.cognition.systemPrompt = data.cognition.systemPrompt
   brain.cognition.contextPrompt = data.cognition.contextPrompt
   brain.behavior.style = data.behavior.style
-  brain.filters = data.filters.map(code => {
-    try {
-      // eslint-disable-next-line no-new-func
-      return eval(`(${code})`) as (text: string) => string
-    } catch {
-      return (t: string) => t
-    }
-  })
+  brain.filters = data.filters
+    .map(name => getFilterByName(name) ?? ((t: string) => t))
   brain.skills = data.skills
 }
 
@@ -51,7 +46,7 @@ export async function exportBrainSettings(): Promise<string> {
   const defaults: BrainSettingsData = {
     cognition: brain.cognition,
     behavior: brain.behavior,
-    filters: brain.filters.map(fn => fn.toString()),
+    filters: brain.filters.map(fn => getFilterName(fn)).filter(Boolean) as string[],
     skills: brain.skills
   }
   return JSON.stringify(defaults)


### PR DESCRIPTION
## Summary
- remove `eval` usage when loading brain settings
- support named filter registry
- update settings UI copy
- add tests for import/export of brain settings

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68810a28d1b48326a6e9b33b4d0a9540