### PR TITLE
Conditionally load pythagora utils

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ VITE_OPENAI_API_KEY=
 VITE_ELEVENLABS_API_KEY=
 VITE_ELECTRIC_URL=http://localhost:5133
 
+# Set to "true" to include the Pythagora logging script. When unset or "false",
+# utils.js is skipped and no requests to /logs are made.
+VITE_USE_PYTHAGORA=false
+
 # Firebase configuration
 VITE_FIREBASE_API_KEY=YOUR_FIREBASE_API_KEY
 VITE_FIREBASE_AUTH_DOMAIN=YOUR_FIREBASE_AUTH_DOMAIN

--- a/index.html
+++ b/index.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LifePilotAI</title>
-    <script src="https://s3.us-east-1.amazonaws.com/assets.pythagora.ai/scripts/utils.js"></script>
+    <script type="module">
+      if (import.meta.env.VITE_USE_PYTHAGORA === 'true') {
+        const s = document.createElement('script');
+        s.src = 'https://s3.us-east-1.amazonaws.com/assets.pythagora.ai/scripts/utils.js';
+        document.head.appendChild(s);
+      }
+    </script>
     <link rel="icon" type="image/x-icon" href="https://s3.us-east-1.amazonaws.com/assets.pythagora.ai/logos/favicon.ico" />
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LifePilotAI</title>
-    <script src="https://s3.us-east-1.amazonaws.com/assets.pythagora.ai/scripts/utils.js"></script>
+    <script type="module">
+      if (import.meta.env.VITE_USE_PYTHAGORA === 'true') {
+        const s = document.createElement('script');
+        s.src = 'https://s3.us-east-1.amazonaws.com/assets.pythagora.ai/scripts/utils.js';
+        document.head.appendChild(s);
+      }
+    </script>
     <link rel="icon" type="image/x-icon" href="https://s3.us-east-1.amazonaws.com/assets.pythagora.ai/logos/favicon.ico" />
   </head>
   <body>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,9 @@ import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
 export default defineConfig({
+  define: {
+    'import.meta.env.VITE_USE_PYTHAGORA': JSON.stringify(process.env.VITE_USE_PYTHAGORA ?? 'false')
+  },
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- load the Pythagora `utils.js` script only when `VITE_USE_PYTHAGORA` is true
- default `VITE_USE_PYTHAGORA` to `false` in `vite.config.ts`
- document the new variable in `.env.example`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68818fe5e53483269be75c8c992eed42