### PR TITLE
Add project API endpoints and integrate storage hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Firebase values are required for authentication to work correctly.
 
 #### Frontend
 - `VITE_API_BASE_URL` – base URL of the remote API
+- The backend exposes `/projects` for project CRUD operations. Requests are made relative to this base URL.
 - `VITE_OPENAI_API_KEY` – OpenAI key used by the browser (optional)
 - `VITE_ELEVENLABS_API_KEY` – ElevenLabs key for voice features (optional)
 - `VITE_ELECTRIC_URL` – URL of the ElectricSQL backend (optional)

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -1,0 +1,40 @@
+import api from './api';
+import type { Project } from '@/types/project';
+
+export const getProjects = async (): Promise<Project[]> => {
+  try {
+    const response = await api.get('/projects');
+    return response.data as Project[];
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
+};
+
+export const createProject = async (project: Partial<Project>): Promise<Project> => {
+  try {
+    const response = await api.post('/projects', project);
+    return response.data as Project;
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
+};
+
+export const updateProject = async (
+  projectId: string,
+  updates: Partial<Project>
+): Promise<Project> => {
+  try {
+    const response = await api.put(`/projects/${projectId}`, updates);
+    return response.data as Project;
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
+};
+
+export const deleteProject = async (projectId: string): Promise<void> => {
+  try {
+    await api.delete(`/projects/${projectId}`);
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
+};

--- a/src/hooks/useProjectStorage.ts
+++ b/src/hooks/useProjectStorage.ts
@@ -1,6 +1,12 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Project } from '@/types/project'
 import { electric } from '@/lib/electric'
+import {
+  getProjects as apiGetProjects,
+  createProject as apiCreateProject,
+  updateProject as apiUpdateProject,
+  deleteProject as apiDeleteProject
+} from '@/api/projects'
 
 /**
  * Stores projects in the local ElectricSQL database. On first load any
@@ -11,9 +17,19 @@ export function useProjectStorage() {
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
-  // initial load + migration
+  // initial load + migration + remote fetch
   useEffect(() => {
     const init = async () => {
+      try {
+        const remote = await apiGetProjects()
+        if (remote && remote.length > 0) {
+          await electric.projects.clear()
+          await electric.projects.bulkPut(remote)
+        }
+      } catch (err) {
+        console.error('Failed to fetch projects from API', err)
+      }
+
       let all = await electric.projects.toArray()
       if (all.length === 0) {
         const stored = localStorage.getItem('lifepilot_projects')
@@ -60,12 +76,7 @@ export function useProjectStorage() {
   }, [])
 
   const createProject = useCallback(async (projectData: Partial<Project>) => {
-    const newProject: Project = {
-      ...projectData,
-      id: crypto.randomUUID(),
-      createdAt: new Date(),
-      updatedAt: new Date()
-    } as Project
+    const newProject = await apiCreateProject(projectData)
     await electric.projects.add(newProject)
     await electric.settings.put({ key: 'activeProjectId', value: newProject.id })
     setActiveProjectId(newProject.id)
@@ -74,14 +85,13 @@ export function useProjectStorage() {
   }, [reload])
 
   const updateProject = useCallback(async (projectId: string, updates: Partial<Project>) => {
-    const existing = await electric.projects.get(projectId)
-    if (existing) {
-      await electric.projects.put({ ...existing, ...updates, updatedAt: new Date() })
-      reload()
-    }
+    const updated = await apiUpdateProject(projectId, updates)
+    await electric.projects.put(updated)
+    reload()
   }, [reload])
 
   const deleteProject = useCallback(async (projectId: string) => {
+    await apiDeleteProject(projectId)
     await electric.projects.delete(projectId)
     const remaining = await electric.projects.toArray()
     if (activeProjectId === projectId) {


### PR DESCRIPTION
## Summary
- add `src/api/projects.ts` with CRUD wrappers around `/projects`
- fetch projects from API in `useProjectStorage`
- call API before updating local Dexie store
- document new `/projects` endpoint usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688191c439a48326a149f6ea4908e9a1