### PR TITLE
Switch API mocks to real endpoints

### DIFF
--- a/src/api/boards.ts
+++ b/src/api/boards.ts
@@ -34,156 +34,16 @@ export interface Board {
 // Endpoint: GET /boards
 // Request: { projectId?: string, type?: string }
 // Response: { boards: Board[] }
-export const getBoards = async (projectId?: string, type?: string) => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      const mockBoards: Board[] = [
-        {
-          id: 'board-1',
-          title: 'Project Tasks',
-          type: 'project',
-          projectId,
-          columns: [
-            {
-              id: 'todo',
-              title: 'To Do',
-              order: 0,
-              color: '#ef4444',
-              cards: [
-                {
-                  id: 'card-1',
-                  title: 'Design wireframes',
-                  description: 'Create initial wireframes for the new feature',
-                  tags: ['design', 'urgent'],
-                  estimate: 4,
-                  progress: 0,
-                  createdAt: new Date(),
-                  updatedAt: new Date()
-                },
-                {
-                  id: 'card-2',
-                  title: 'Research competitors',
-                  description: 'Analyze competitor solutions',
-                  tags: ['research'],
-                  estimate: 2,
-                  progress: 0,
-                  createdAt: new Date(),
-                  updatedAt: new Date()
-                }
-              ]
-            },
-            {
-              id: 'doing',
-              title: 'In Progress',
-              order: 1,
-              color: '#3b82f6',
-              cards: [
-                {
-                  id: 'card-3',
-                  title: 'Implement authentication',
-                  description: 'Add user login and registration',
-                  tags: ['development'],
-                  estimate: 8,
-                  progress: 60,
-                  createdAt: new Date(),
-                  updatedAt: new Date()
-                }
-              ]
-            },
-            {
-              id: 'done',
-              title: 'Done',
-              order: 2,
-              color: '#10b981',
-              cards: [
-                {
-                  id: 'card-4',
-                  title: 'Setup project structure',
-                  description: 'Initialize project with proper folder structure',
-                  tags: ['setup'],
-                  estimate: 1,
-                  progress: 100,
-                  createdAt: new Date(),
-                  updatedAt: new Date()
-                }
-              ]
-            }
-          ]
-        }
-      ];
-
-      if (type === 'habit') {
-        mockBoards.push({
-          id: 'board-2',
-          title: 'Habit Builder',
-          type: 'habit',
-          columns: [
-            {
-              id: 'ideas',
-              title: 'Habit Ideas',
-              order: 0,
-              color: '#8b5cf6',
-              cards: [
-                {
-                  id: 'habit-1',
-                  title: 'Morning meditation',
-                  description: '10 minutes daily meditation',
-                  tags: ['wellness'],
-                  metadata: { frequency: 'daily', streak: 0 },
-                  createdAt: new Date(),
-                  updatedAt: new Date()
-                }
-              ]
-            },
-            {
-              id: 'active',
-              title: 'Scheduled',
-              order: 1,
-              color: '#3b82f6',
-              cards: [
-                {
-                  id: 'habit-2',
-                  title: 'Daily exercise',
-                  description: '30 minutes workout',
-                  tags: ['fitness'],
-                  metadata: { frequency: 'daily', streak: 7 },
-                  createdAt: new Date(),
-                  updatedAt: new Date()
-                }
-              ]
-            },
-            {
-              id: 'completed',
-              title: 'Mastered',
-              order: 2,
-              color: '#10b981',
-              cards: [
-                {
-                  id: 'habit-3',
-                  title: 'Drink 8 glasses water',
-                  description: 'Stay hydrated throughout the day',
-                  tags: ['health'],
-                  metadata: { frequency: 'daily', streak: 30 },
-                  createdAt: new Date(),
-                  updatedAt: new Date()
-                }
-              ]
-            }
-          ]
-        });
-      }
-
-      resolve({ boards: mockBoards });
-    }, 500);
-  });
-
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.get('/boards', { params: { projectId, type } });
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+export const getBoards = async (
+  projectId?: string,
+  type?: string
+): Promise<{ boards: Board[] }> => {
+  try {
+    const response = await api.get('/boards', { params: { projectId, type } });
+    return response.data as { boards: Board[] };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };
 
 // Description: Move a card between columns
@@ -191,19 +51,17 @@ export const getBoards = async (projectId?: string, type?: string) => {
 // Request: { cardId: string, fromColumnId: string, toColumnId: string, boardId: string }
 // Response: { success: boolean }
 export const moveCard = async (cardId: string, fromColumnId: string, toColumnId: string, boardId: string) => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({ success: true });
-    }, 300);
-  });
-
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.post('/boards/move-card', { cardId, fromColumnId, toColumnId, boardId });
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+  try {
+    const response = await api.post('/boards/move-card', {
+      cardId,
+      fromColumnId,
+      toColumnId,
+      boardId,
+    });
+    return response.data as { success: boolean };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };
 
 // Description: Add a new card to a column
@@ -211,30 +69,12 @@ export const moveCard = async (cardId: string, fromColumnId: string, toColumnId:
 // Request: { columnId: string, boardId: string, card: Partial<BoardCard> }
 // Response: { card: BoardCard }
 export const addCard = async (columnId: string, boardId: string, card: Partial<BoardCard>) => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      const newCard: BoardCard = {
-        id: crypto.randomUUID(),
-        title: card.title || 'New Card',
-        description: card.description,
-        tags: card.tags || [],
-        estimate: card.estimate,
-        progress: card.progress || 0,
-        metadata: card.metadata,
-        createdAt: new Date(),
-        updatedAt: new Date()
-      };
-      resolve({ card: newCard });
-    }, 300);
-  });
-
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.post('/boards/add-card', { columnId, boardId, card });
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+  try {
+    const response = await api.post('/boards/add-card', { columnId, boardId, card });
+    return response.data as { card: BoardCard };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };
 
 // Description: Update a card
@@ -242,25 +82,12 @@ export const addCard = async (columnId: string, boardId: string, card: Partial<B
 // Request: { cardId: string, updates: Partial<BoardCard> }
 // Response: { card: BoardCard }
 export const updateCard = async (cardId: string, updates: Partial<BoardCard>) => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({ 
-        card: { 
-          id: cardId, 
-          ...updates, 
-          updatedAt: new Date() 
-        } 
-      });
-    }, 300);
-  });
-
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.put('/boards/update-card', { cardId, updates });
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+  try {
+    const response = await api.put('/boards/update-card', { cardId, updates });
+    return response.data as { card: BoardCard };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };
 
 // Description: Get board templates
@@ -268,61 +95,10 @@ export const updateCard = async (cardId: string, updates: Partial<BoardCard>) =>
 // Request: {}
 // Response: { templates: BoardTemplate[] }
 export const getBoardTemplates = async () => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        templates: [
-          {
-            id: 'project',
-            name: 'Project Manager',
-            type: 'project',
-            columns: [
-              { id: 'todo', title: 'To Do', color: '#ef4444', order: 0 },
-              { id: 'doing', title: 'In Progress', color: '#3b82f6', order: 1 },
-              { id: 'done', title: 'Done', color: '#10b981', order: 2 }
-            ]
-          },
-          {
-            id: 'habit',
-            name: 'Habit Builder',
-            type: 'habit',
-            columns: [
-              { id: 'ideas', title: 'Habit Ideas', color: '#8b5cf6', order: 0 },
-              { id: 'active', title: 'Scheduled', color: '#3b82f6', order: 1 },
-              { id: 'completed', title: 'Mastered', color: '#10b981', order: 2 }
-            ]
-          },
-          {
-            id: 'skill',
-            name: 'Skill Roadmap',
-            type: 'skill',
-            columns: [
-              { id: 'learning', title: 'Learning Goals', color: '#f59e0b', order: 0 },
-              { id: 'practice', title: 'In Practice', color: '#3b82f6', order: 1 },
-              { id: 'mastered', title: 'Mastered', color: '#10b981', order: 2 }
-            ]
-          },
-          {
-            id: 'mood',
-            name: 'Mood Tracker',
-            type: 'mood',
-            columns: [
-              { id: 'sad', title: '😢 Sad', color: '#6b7280', order: 0 },
-              { id: 'neutral', title: '😐 Neutral', color: '#f59e0b', order: 1 },
-              { id: 'good', title: '😊 Good', color: '#3b82f6', order: 2 },
-              { id: 'great', title: '😄 Great', color: '#10b981', order: 3 }
-            ]
-          }
-        ]
-      });
-    }, 300);
-  });
-
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.get('/boards/templates');
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+  try {
+    const response = await api.get('/boards/templates');
+    return response.data as { templates: any[] };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };

--- a/src/api/goals.ts
+++ b/src/api/goals.ts
@@ -5,47 +5,12 @@ import api from './api';
 // Request: {}
 // Response: { goals: Array<{ _id: string, title: string, progress: number, category: string, status: string }> }
 export const getGoals = async () => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        goals: [
-          {
-            _id: '1',
-            title: 'Master React Advanced Patterns',
-            progress: 75,
-            category: 'Learning',
-            status: 'active'
-          },
-          {
-            _id: '2',
-            title: 'Complete Marathon Training',
-            progress: 60,
-            category: 'Fitness',
-            status: 'active'
-          },
-          {
-            _id: '3',
-            title: 'Build Side Project',
-            progress: 30,
-            category: 'Career',
-            status: 'active'
-          },
-          {
-            _id: '4',
-            title: 'Read 12 Books This Year',
-            progress: 85,
-            category: 'Personal',
-            status: 'active'
-          }
-        ]
-      });
-    }, 500);
-  });
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.get('/goals');
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+  try {
+    const response = await api.get('/goals');
+    return response.data as {
+      goals: Array<{ _id: string; title: string; progress: number; category: string; status: string }>;
+    };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };

--- a/src/api/roadmap.ts
+++ b/src/api/roadmap.ts
@@ -16,69 +16,10 @@ export interface Milestone {
 // Request: {}
 // Response: { milestones: Milestone[] }
 export const getRoadmap = async () => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        milestones: [
-          {
-            id: 'milestone-1',
-            title: 'Define Core Values',
-            description: 'Discover what truly matters to you',
-            completed: true,
-            xpReward: 50,
-            requiredLevel: 1,
-            category: 'foundation',
-            widgetType: 'values-wheel'
-          },
-          {
-            id: 'milestone-2',
-            title: 'Set First Goals',
-            description: 'Create your initial set of life goals',
-            completed: true,
-            xpReward: 75,
-            requiredLevel: 2,
-            category: 'planning',
-            widgetType: 'goals-progress'
-          },
-          {
-            id: 'milestone-3',
-            title: 'First Habit Streak',
-            description: 'Maintain a habit for 7 consecutive days',
-            completed: false,
-            xpReward: 100,
-            requiredLevel: 3,
-            category: 'habits',
-            widgetType: 'habit-streaks'
-          },
-          {
-            id: 'milestone-4',
-            title: 'Skill Assessment',
-            description: 'Complete your first skills evaluation',
-            completed: false,
-            xpReward: 125,
-            requiredLevel: 4,
-            category: 'development',
-            widgetType: 'skills-radar'
-          },
-          {
-            id: 'milestone-5',
-            title: 'Focus Master',
-            description: 'Complete 10 deep focus sessions',
-            completed: false,
-            xpReward: 150,
-            requiredLevel: 5,
-            category: 'productivity',
-            widgetType: 'focus-time'
-          }
-        ]
-      });
-    }, 500);
-  });
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.get('/roadmap');
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+  try {
+    const response = await api.get('/roadmap');
+    return response.data as { milestones: Milestone[] };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };

--- a/src/api/subscription.ts
+++ b/src/api/subscription.ts
@@ -6,37 +6,12 @@ import { Subscription, UsageStats } from '@/types/subscription';
 // Request: {}
 // Response: { subscription: Subscription | null, usage: UsageStats }
 export const getSubscription = async () => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        subscription: {
-          id: 'sub_1',
-          userId: 'user_1',
-          planId: 'freemium',
-          status: 'active',
-          currentPeriodStart: new Date(),
-          currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-          cancelAtPeriodEnd: false,
-          stripeCustomerId: 'cus_test',
-          stripeSubscriptionId: 'sub_test',
-          billingCycle: 'monthly'
-        },
-        usage: {
-          aiMessagesUsed: 150,
-          widgetsActive: 2,
-          teamSeatsUsed: 1
-        }
-      });
-    }, 500);
-  });
-
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.get('/subscription');
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+  try {
+    const response = await api.get('/subscription');
+    return response.data as { subscription: Subscription | null; usage: UsageStats };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };
 
 // Description: Create Stripe checkout session
@@ -44,22 +19,12 @@ export const getSubscription = async () => {
 // Request: { priceId: string, billingCycle: 'monthly' | 'yearly' }
 // Response: { sessionId: string, url: string }
 export const createCheckoutSession = async (priceId: string, billingCycle: 'monthly' | 'yearly') => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        sessionId: 'cs_test_session',
-        url: 'https://checkout.stripe.com/pay/cs_test_session'
-      });
-    }, 500);
-  });
-
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.post('/subscription/checkout', { priceId, billingCycle });
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+  try {
+    const response = await api.post('/subscription/checkout', { priceId, billingCycle });
+    return response.data as { sessionId: string; url: string };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };
 
 // Description: Cancel subscription
@@ -67,33 +32,12 @@ export const createCheckoutSession = async (priceId: string, billingCycle: 'mont
 // Request: { cancelAtPeriodEnd: boolean }
 // Response: { success: boolean, subscription: Subscription }
 export const cancelSubscription = async (cancelAtPeriodEnd: boolean = true) => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        success: true,
-        subscription: {
-          id: 'sub_1',
-          userId: 'user_1',
-          planId: 'freemium',
-          status: 'active',
-          currentPeriodStart: new Date(),
-          currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-          cancelAtPeriodEnd: true,
-          stripeCustomerId: 'cus_test',
-          stripeSubscriptionId: 'sub_test',
-          billingCycle: 'monthly'
-        }
-      });
-    }, 500);
-  });
-
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.post('/subscription/cancel', { cancelAtPeriodEnd });
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+  try {
+    const response = await api.post('/subscription/cancel', { cancelAtPeriodEnd });
+    return response.data as { success: boolean; subscription: Subscription };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };
 
 // Description: Update subscription plan
@@ -101,31 +45,10 @@ export const cancelSubscription = async (cancelAtPeriodEnd: boolean = true) => {
 // Request: { priceId: string, billingCycle: 'monthly' | 'yearly' }
 // Response: { success: boolean, subscription: Subscription }
 export const updateSubscription = async (priceId: string, billingCycle: 'monthly' | 'yearly') => {
-  // Mocking the response
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        success: true,
-        subscription: {
-          id: 'sub_1',
-          userId: 'user_1',
-          planId: 'personal',
-          status: 'active',
-          currentPeriodStart: new Date(),
-          currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-          cancelAtPeriodEnd: false,
-          stripeCustomerId: 'cus_test',
-          stripeSubscriptionId: 'sub_test',
-          billingCycle
-        }
-      });
-    }, 500);
-  });
-
-  // Uncomment the below lines to make an actual API call
-  // try {
-  //   return await api.post('/subscription/update', { priceId, billingCycle });
-  // } catch (error) {
-  //   throw new Error(error?.response?.data?.error || error.message);
-  // }
+  try {
+    const response = await api.post('/subscription/update', { priceId, billingCycle });
+    return response.data as { success: boolean; subscription: Subscription };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };

--- a/src/api/widgets.ts
+++ b/src/api/widgets.ts
@@ -190,113 +190,12 @@ export const generateWidgets = async (
   context: string,
   activeWidgets: string[] = []
 ) => {
-  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
-
-  if (apiKey) {
-    try {
-      const body = {
-        model: 'gpt-3.5-turbo',
-        messages: [
-          {
-            role: 'system',
-            content:
-              'You are Aura, an assistant that suggests dashboard widgets based on the user\'s context. Return JSON with a `widgets` array.'
-          },
-          { role: 'user', content: context }
-        ]
-      };
-
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`
-        },
-        body: JSON.stringify(body)
-      });
-
-      const data = await res.json();
-      const content = data.choices?.[0]?.message?.content?.trim() || '';
-
-      try {
-        const parsed = JSON.parse(content);
-        const widgets = Array.isArray(parsed.widgets) ? parsed.widgets : [];
-        const filtered = widgets.filter((w: any) => !activeWidgets.includes(w.id));
-        return { widgets: filtered };
-      } catch (err) {
-        console.error('generateWidgets: failed to parse AI response', err);
-      }
-    } catch (err) {
-      console.error('generateWidgets: OpenAI request failed', err);
-    }
+  try {
+    const response = await api.post('/widgets/generate', { context, activeWidgets });
+    return response.data as { widgets: any[] };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
   }
-
-  // Keyword fallback
-  return new Promise<{ widgets: any[] }>((resolve) => {
-    setTimeout(() => {
-      const availableWidgets = fallbackWidgets;
-
-      let selectedWidgets: any[] = [];
-
-      const lower = context.toLowerCase();
-      if (lower.includes('goal')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'goals-progress'));
-      }
-      if (lower.includes('skill')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'skills-radar'));
-      }
-      if (lower.includes('value')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'values-wheel'));
-      }
-      if (lower.includes('focus') || lower.includes('today')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'daily-focus'));
-      }
-      if (lower.includes('mood') || lower.includes('feel')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'mood-tracker'));
-      }
-      if (lower.includes('habit')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'habit-streaks'));
-      }
-      if (lower.includes('performance') || lower.includes('week')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'weekly-stats'));
-      }
-      if (lower.includes('time') || lower.includes('productivity')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'focus-time'));
-      }
-      if (lower.includes('analytics') || lower.includes('dashboard') || lower.includes('metrics')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'analytics-dashboard'));
-      }
-      if (lower.includes('project') || lower.includes('task') || lower.includes('manage')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'project-manager'));
-      }
-      if (lower.includes('board') || lower.includes('kanban')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'project-board'));
-      }
-      if (lower.includes('habit') && (lower.includes('board') || lower.includes('track'))) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'habit-board'));
-      }
-      if (lower.includes('skill') && (lower.includes('board') || lower.includes('roadmap'))) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'skill-board'));
-      }
-      if (lower.includes('mood') && lower.includes('board')) {
-        selectedWidgets.push(availableWidgets.find((w) => w.id === 'mood-board'));
-      }
-
-      if (selectedWidgets.length === 0) {
-        selectedWidgets = [
-          availableWidgets.find((w) => w.id === 'goals-progress'),
-          availableWidgets.find((w) => w.id === 'daily-focus'),
-          availableWidgets.find((w) => w.id === 'analytics-dashboard')
-        ];
-      }
-
-      selectedWidgets = selectedWidgets
-        .filter(Boolean)
-        .filter((widget) => !activeWidgets.includes(widget.id));
-
-      resolve({ widgets: selectedWidgets });
-    }, 800);
-  });
 };
 
 // Description: Update widgets with new data based on chat context
@@ -304,35 +203,10 @@ export const generateWidgets = async (
 // Request: { context: string, widgets: WidgetData[] }
 // Response: { widgets: WidgetData[] }
 export const updateWidgets = async (context: string, widgets: any[]) => {
-  return new Promise<{ widgets: any[] }>((resolve) => {
-    setTimeout(() => {
-      const lower = context.toLowerCase();
-      const updated = widgets.map((w) => {
-        if (w.id === 'goals-progress' && lower.includes('goal')) {
-          return {
-            ...w,
-            data: w.data.map((g: any) => ({
-              ...g,
-              progress: Math.min(100, g.progress + 5)
-            }))
-          };
-        }
-        if (w.id === 'habit-streaks' && lower.includes('habit')) {
-          return {
-            ...w,
-            data: w.data.map((h: any) => ({
-              ...h,
-              streak: h.streak + 1
-            }))
-          };
-        }
-        if (w.id === 'mood-tracker' && lower.includes('mood')) {
-          const mood = Math.max(1, Math.min(5, Math.round(Math.random() * 5)));
-          return { ...w, data: [...w.data.slice(1), { date: 'Today', mood }] };
-        }
-        return w;
-      });
-      resolve({ widgets: updated });
-    }, 300);
-  });
+  try {
+    const response = await api.post('/widgets/update', { context, widgets });
+    return response.data as { widgets: any[] };
+  } catch (error: any) {
+    throw new Error(error?.response?.data?.message || error.message);
+  }
 };


### PR DESCRIPTION
## Summary
- replace mocked board APIs with real server requests
- update goals, roadmap, widgets and subscription APIs
- remove all `setTimeout` mocks

## Testing
- `npm test` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688193dcc6bc83268e31c57d2147504e