### PR TITLE
Add Vite proxy for backend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Firebase values are required for authentication to work correctly.
 #### Frontend
 - `VITE_API_BASE_URL` – base URL of the remote API
 - The backend exposes `/projects` for project CRUD operations. Requests are made relative to this base URL.
+- During development the Vite server proxies API paths like `/projects`, `/subscription`, `/users`, and more to this URL.
 - `VITE_OPENAI_API_KEY` – OpenAI key used by the browser (optional)
 - `VITE_ELEVENLABS_API_KEY` – ElevenLabs key for voice features (optional)
 - `VITE_ELECTRIC_URL` – URL of the ElectricSQL backend (optional)
@@ -76,6 +77,9 @@ Install dependencies with `npm install` (or `yarn`). Start the development serve
 npm run dev
 ```
 This command starts the Vite dev server.
+Ensure your backend is running at `VITE_API_BASE_URL`; the dev server will proxy
+API requests like `/projects` or `/subscription` to that address so the client
+can use relative URLs.
 
 ## Brain prompt configuration
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,11 @@
 import path from "path"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
+import * as dotenv from "dotenv"
+
+dotenv.config()
+
+const API_BASE_URL = process.env.VITE_API_BASE_URL
 
 export default defineConfig({
   define: {
@@ -21,7 +26,62 @@ export default defineConfig({
       '/logs': {
         target: 'http://localhost:4444',
         changeOrigin: true,
-      }
+      },
+      '/projects': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      '/subscription': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      '/users': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      '/boards': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      '/widgets': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      '/goals': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      '/roadmap': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      '/achievements': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      '/rewards': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      '/character': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      '/auth': {
+        target: API_BASE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
     },
     allowedHosts: [
       'localhost',


### PR DESCRIPTION
## Summary
- load `.env` variables in `vite.config.ts`
- proxy API routes to `VITE_API_BASE_URL`
- document proxy usage in `README`

## Testing
- `npm test` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68819ceac7888326acd1eda1766ed23c