### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,13 @@ Copy the provided `.env.example` file to `.env` in the project root and replace 
 Frontend variables must be prefixed with `VITE_` so Vite can expose them to the client. The
 Firebase values are required for authentication to work correctly.
 
-
--#### Frontend
-- `VITE_API_BASE_URL` – base URL of the remote API
+#### Frontend
+- `VITE_API_BASE_URL` – base URL of the remote API (e.g., `http://localhost:3000`)
 - The backend exposes `/projects` for project CRUD operations. Requests are made relative to this base URL.
 - During development the Vite server proxies API paths like `/projects`, `/subscription`, `/users`, and more to this URL.
 - `VITE_OPENAI_API_KEY` – OpenAI key used by the browser (optional)
 - `VITE_ELEVENLABS_API_KEY` – ElevenLabs key for voice features (optional)
-- `VITE_ELECTRIC_URL` – URL of the ElectricSQL backend (optional)
+- `VITE_ELECTRIC_URL` – URL of the ElectricSQL backend (e.g., `http://localhost:5133`). Postgres typically listens on `5432`.
 - `VITE_FIREBASE_API_KEY` – Firebase project API key
 - `VITE_FIREBASE_AUTH_DOMAIN` – Firebase auth domain
 - `VITE_FIREBASE_PROJECT_ID` – Firebase project ID
@@ -62,15 +61,33 @@ Firebase values are required for authentication to work correctly.
 - `VITE_FIREBASE_MESSAGING_SENDER_ID` – Firebase messaging sender ID
 - `VITE_FIREBASE_APP_ID` – Firebase app ID
 
+### Backend API
+The app communicates with a separate API server defined by `VITE_API_BASE_URL`.
+Run your backend locally so it listens on **3000** (or update the URL). A typical
+Node project can be started with:
+
+```bash
+cd path/to/api && npm start
+```
+
+Rails users can run:
+
+```bash
+bundle exec rails s -p 3000
+```
+
 ### ElectricSQL
 Setting `VITE_ELECTRIC_URL` enables realtime sync through an [ElectricSQL](https://electric-sql.com/) backend.
-To run the server locally, install the Electric CLI and start it:
+To run the server locally, install the Electric CLI and start it (see the [Quickstart guide](https://electric-sql.com/docs/quickstart)):
 
 ```bash
 npx electric-sql dev
 ```
 
-The server listens on port **5133** by default. Leave `VITE_ELECTRIC_URL` unset to disable sync. If the backend isn't running, the app may log repeated `ECONNRESET` errors as it attempts to connect.
+This command spins up Electric and Postgres containers. Electric's websocket
+endpoint usually runs on port **5133** while Postgres listens on **5432**.
+Leave `VITE_ELECTRIC_URL` unset to disable sync. If the backend isn't running,
+the app may log repeated `ECONNRESET` errors as it attempts to connect.
 
 ### 3. Firebase Console Setup
 1. Open the [Firebase console](https://console.firebase.google.com/) and navigate to **Authentication → Sign‑in method**.
@@ -87,6 +104,18 @@ Install dependencies with `npm install` (or `yarn`). Start the development serve
 npm run dev
 ```
 This command starts the Vite dev server.
+In another terminal start your backend API (typically on port **3000**), for example:
+
+```bash
+cd path/to/api && npm start
+```
+
+Run the ElectricSQL service as well:
+
+```bash
+npx electric-sql dev
+```
+This starts Postgres on **5432** and Electric on **5133**.
 Ensure your backend is running at `VITE_API_BASE_URL`; the dev server will proxy
 API requests like `/projects` or `/subscription` to that address so the client
 can use relative URLs.


### PR DESCRIPTION
## Summary
- clarify environment variables for API and ElectricSQL
- add instructions for starting the backend API and ElectricSQL

## Testing
- `npm test` *(fails: localStorage is not defined)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6881ac16696c8326bee24b5c10b74e1a