### PR TITLE
Add ElectricSQL DB init script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "predev": "ts-node scripts/init-db.ts",
     "dev": "vite",
     "dev:client": "vite",
     "build": "vite build",
@@ -97,7 +98,8 @@
     "vite": "^5.4.8",
     "vitest": "^3.2.4",
     "@testing-library/react": "^14.2.1",
-    "jsdom": "^24.0.0"
+    "jsdom": "^24.0.0",
+    "ts-node": "^10.9.2"
   },
   "packageManager": "yarn@4.9.2+sha512.1fc009bc09d13cfd0e19efa44cbfc2b9cf6ca61482725eb35bbc5e257e093ebf4130db6dfe15d604ff4b79efd8e1e8e99b25fa7d0a6197c9f9826358d4d65c3c"
 }

--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -1,0 +1,20 @@
+import path from 'path'
+
+// Database initialization using ElectricSQL migrations
+
+async function run() {
+  try {
+    const { Database } = await import('wa-sqlite')
+    const { initSQLite } = await import('../src/lib/sqlite')
+
+    const dbPath = path.resolve(__dirname, '../blue-ocean.db')
+    const db = new Database(dbPath)
+    await initSQLite(db)
+    await db.close()
+    console.log('Database initialized')
+  } catch (err) {
+    console.error('Failed to initialise database', err)
+  }
+}
+
+run()

--- a/src/lib/sqlite.ts
+++ b/src/lib/sqlite.ts
@@ -1,0 +1,5 @@
+export async function initSQLite(db: any) {
+  const { electrify } = await import('electric-sql/node')
+  const { schema } = await import('../sqlite/migrations')
+  await electrify(db, schema)
+}

--- a/src/sqlite/migrations.ts
+++ b/src/sqlite/migrations.ts
@@ -1,0 +1,4 @@
+export const schema = {
+  version: 1,
+  tables: {},
+}


### PR DESCRIPTION
## Summary
- generate SQLite db on the fly for Aura using ElectricSQL
- call this script before dev server starts via `predev`
- expose helper `initSQLite` and placeholder migrations

## Testing
- `npm test` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6882926e9544832682c3ea25edb6c922