### PR TITLE
Enable life plan chat on first login

### DIFF
--- a/src/components/dashboard/AuraLayout.tsx
+++ b/src/components/dashboard/AuraLayout.tsx
@@ -7,6 +7,7 @@ import { FloatingAuraSphere } from './FloatingAuraSphere';
 import { BottomChatSection } from './BottomChatSection';
 import { EmptyDashboardState } from './EmptyDashboardState';
 import { UnifiedPlanChatModal } from './UnifiedPlanChatModal';
+import { LifePlanChatModal } from './LifePlanChatModal';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { GoalsModal } from './modals/GoalsModal';
 import { TasksModal } from './modals/TasksModal';
@@ -74,7 +75,8 @@ function AuraLayoutContent() {
     // Only make decisions after loading is complete
     if (!projectsLoading) {
       if (projects.length === 0 && !isCreatingProject && !showPlanModal) {
-        if (import.meta.env.DEV) console.log("AuraLayout - No projects found, showing creation modal");
+        if (import.meta.env.DEV) console.log("AuraLayout - No projects found, showing life plan modal");
+        setPlanType('life');
         setShowPlanModal(true);
       } else if (projects.length > 0 && !activeProject && !isCreatingProject && !showPlanModal) {
         if (import.meta.env.DEV) console.log("AuraLayout - Projects exist but no active project, using first project");
@@ -154,16 +156,23 @@ function AuraLayoutContent() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 text-white overflow-hidden flex">
-      {/* Unified Plan Chat Modal */}
-      <UnifiedPlanChatModal
-        isOpen={showPlanModal}
-        onClose={() => {
-          setShowPlanModal(false);
-          setIsCreatingProject(false);
-        }}
-        onComplete={handlePlanComplete}
-        planType={planType}
-      />
+      {/* Plan Chat Modal */}
+      {planType === 'life' ? (
+        <LifePlanChatModal
+          isOpen={showPlanModal}
+          onComplete={handlePlanComplete}
+        />
+      ) : (
+        <UnifiedPlanChatModal
+          isOpen={showPlanModal}
+          onClose={() => {
+            setShowPlanModal(false);
+            setIsCreatingProject(false);
+          }}
+          onComplete={handlePlanComplete}
+          planType={planType}
+        />
+      )}
 
       {/* Project Sidebar - Now visible on all screen sizes */}
       <ProjectSidebar

--- a/src/components/dashboard/LifePlanChatModal.tsx
+++ b/src/components/dashboard/LifePlanChatModal.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Send, Sparkles, Mic, MicOff } from 'lucide-react';
 import { useChatContext } from '@/contexts/ChatContext';
 import { useProjectStorage } from '@/hooks/useProjectStorage';
+import { useVoiceInput } from '@/hooks/useVoiceInput';
 
 interface LifePlanStep {
   id: string;
@@ -56,8 +57,8 @@ export function LifePlanChatModal({ isOpen, onComplete }: LifePlanChatModalProps
   const [currentStep, setCurrentStep] = useState(0);
   const [responses, setResponses] = useState<Record<string, string>>({});
   const [inputValue, setInputValue] = useState('');
-  const [isListening, setIsListening] = useState(false);
   const [chatHistory, setChatHistory] = useState<Array<{id: string, sender: 'user' | 'aura', content: string}>>([]);
+  const { startRecording, stopRecording, transcript, setTranscript, isRecording } = useVoiceInput();
   const { setAuraState } = useChatContext();
   const { createProject } = useProjectStorage();
 
@@ -78,20 +79,21 @@ export function LifePlanChatModal({ isOpen, onComplete }: LifePlanChatModalProps
     }
   }, [isOpen, chatHistory.length, currentStepData.question, setAuraState]);
 
-  const handleSendMessage = async () => {
-    if (!inputValue.trim()) return;
+  const handleSendMessage = async (text?: string) => {
+    const message = (text ?? inputValue).trim();
+    if (!message) return;
 
     const userMessage = {
       id: Date.now().toString(),
       sender: 'user' as const,
-      content: inputValue.trim()
+      content: message
     };
 
     // Add user message
     setChatHistory(prev => [...prev, userMessage]);
     
     // Store response
-    const newResponses = { ...responses, [currentStepData.id]: inputValue.trim() };
+    const newResponses = { ...responses, [currentStepData.id]: message };
     setResponses(newResponses);
     
     setInputValue('');
@@ -204,10 +206,22 @@ export function LifePlanChatModal({ isOpen, onComplete }: LifePlanChatModalProps
   };
 
   const toggleVoiceInput = () => {
-    setIsListening(!isListening);
-    setAuraState(isListening ? 'idle' : 'listening');
-    // TODO: Implement actual voice recognition
+    if (isRecording) {
+      stopRecording();
+      setAuraState('idle');
+    } else {
+      setTranscript('');
+      startRecording();
+      setAuraState('listening');
+    }
   };
+
+  useEffect(() => {
+    if (!isRecording && transcript) {
+      handleSendMessage(transcript);
+      setTranscript('');
+    }
+  }, [isRecording, transcript]);
 
   if (!isOpen) return null;
 
@@ -290,9 +304,9 @@ export function LifePlanChatModal({ isOpen, onComplete }: LifePlanChatModalProps
               onClick={toggleVoiceInput}
               variant="outline"
               size="icon"
-              className={`${isListening ? 'bg-orange-100 border-orange-300 text-orange-600' : ''}`}
+              className={`${isRecording ? 'bg-orange-100 border-orange-300 text-orange-600' : ''}`}
             >
-              {isListening ? <MicOff className="w-4 h-4" /> : <Mic className="w-4 h-4" />}
+              {isRecording ? <MicOff className="w-4 h-4" /> : <Mic className="w-4 h-4" />}
             </Button>
 
             <Button


### PR DESCRIPTION
## Summary
- use `LifePlanChatModal` when no projects exist
- default to life-plan creation on first login

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68828c8daec48326975bdb694ab6638a