### PR TITLE
Populate SQLite schema and update tests

### DIFF
--- a/src/__tests__/migrations.test.ts
+++ b/src/__tests__/migrations.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { schema } from '../sqlite/migrations'
+
+describe('sqlite schema', () => {
+  it('defines all required tables', () => {
+    const tables = Object.keys(schema.tables).sort()
+    expect(tables).toEqual([
+      'brain_settings',
+      'messages',
+      'projects',
+      'settings',
+      'summaries',
+      'tips'
+    ])
+  })
+})

--- a/src/__tests__/widgets.test.ts
+++ b/src/__tests__/widgets.test.ts
@@ -1,5 +1,36 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock API client used by widget helpers
+const mockWidgets = [
+  { id: 'goals-progress', data: [{ id: 1, progress: 60 }] }
+]
+
+vi.mock('../api/api', () => ({
+  default: {
+    post: vi.fn((url: string, body: any) => {
+      if (url === '/widgets/generate') {
+        const active: string[] = body?.activeWidgets ?? []
+        const filtered = mockWidgets.filter(w => !active.includes(w.id))
+        return Promise.resolve({ data: { widgets: filtered } })
+      }
+      if (url === '/widgets/update') {
+        const current = body?.widgets?.[0]?.data?.[0]?.progress ?? 50
+        return Promise.resolve({ data: { widgets: [{ id: 'goals-progress', data: [{ id: 1, progress: current + 25 }] }] } })
+      }
+      return Promise.resolve({ data: {} })
+    }),
+    interceptors: { request: { use: () => {} }, response: { use: () => {} } }
+  }
+}))
+
 import { generateWidgets, updateWidgets } from '../api/widgets'
+
+// Basic localStorage mock for API module used in tests
+(global as any).localStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined
+}
 
 // ensure no API key so fallback logic runs
 process.env.VITE_OPENAI_API_KEY = ''

--- a/src/sqlite/migrations.ts
+++ b/src/sqlite/migrations.ts
@@ -1,4 +1,65 @@
-export const schema = {
+export interface TableDefinition {
+  columns: string[]
+}
+
+/**
+ * ElectricSQL schema description used for local database initialisation.
+ * Only the table structure is required here so the app can create the
+ * IndexedDB/SQLite replica and sync it with the backend.
+ */
+export const schema: { version: number; tables: Record<string, TableDefinition> } = {
   version: 1,
-  tables: {},
+  tables: {
+    projects: {
+      columns: [
+        'id text primary key',
+        'name text not null',
+        'icon text not null',
+        'category text not null',
+        'createdAt text not null',
+        'updatedAt text not null',
+        'profile text',
+        'character text',
+        'milestones text',
+        'widgets text',
+        'chatHistory text'
+      ]
+    },
+    messages: {
+      columns: [
+        'id integer primary key autoincrement',
+        'projectId text not null',
+        'sender text not null',
+        'text text',
+        'timestamp text not null'
+      ]
+    },
+    summaries: {
+      columns: [
+        'id text primary key',
+        'summary text not null',
+        'createdAt text not null'
+      ]
+    },
+    settings: {
+      columns: [
+        'key text primary key',
+        'value text not null'
+      ]
+    },
+    brain_settings: {
+      columns: [
+        'key text primary key',
+        'value text not null'
+      ]
+    },
+    tips: {
+      columns: [
+        'id text primary key',
+        'projectId text not null',
+        'tip text not null',
+        'createdAt text not null'
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- define full table structure in `src/sqlite/migrations.ts`
- mock API client inside widget tests so they run without a backend
- add a test that checks the schema tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b5f45a18832692f22b61ff8ed3b7