### PR TITLE
Initialize SQLite on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ Run the ElectricSQL service as well:
 npx electric-sql dev
 ```
 This starts Postgres on **5432** and Electric on **5133**.
+
+### 5. Database initialization
+When `npm run dev` starts it first executes the `predev` script defined in
+`package.json`:
+
+```json
+"predev": "ts-node scripts/init-db.ts"
+```
+
+The script loads `initSQLite` from `src/lib/sqlite.ts`, opens `blue-ocean.db`
+using `wa-sqlite` and applies any migrations. If the file doesn't exist it will
+be created automatically. Restart the dev server to reapply migrations after
+changing the schema.
 Ensure your backend is running at `VITE_API_BASE_URL`; the dev server will proxy
 API requests like `/projects` or `/subscription` to that address so the client
 can use relative URLs.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,19 @@ import App from './App.tsx'
 import './index.css'
 import { loadBrainSettings } from './services/BrainSettingsService'
 
+async function initDatabase() {
+  try {
+    const { Database } = await import('wa-sqlite')
+    const { initSQLite } = await import('./lib/sqlite')
+    const db = new Database('blue-ocean.db')
+    await initSQLite(db)
+    await db.close()
+    if (import.meta.env.DEV) console.log('[Main] SQLite schema applied')
+  } catch (err) {
+    console.error('[Main] Failed to initialise SQLite', err)
+  }
+}
+
 // Suppress console.log statements in production builds
 if (import.meta.env.PROD) {
   console.log = () => {};
@@ -42,6 +55,7 @@ window.addEventListener('unhandledrejection', (event) => {
 
 async function start() {
   try {
+    await initDatabase()
     await loadBrainSettings()
     if (import.meta.env.DEV) console.log('[Main] Creating React root...')
     const root = ReactDOM.createRoot(document.getElementById('root')!)


### PR DESCRIPTION
## Summary
- apply SQLite migrations during app startup
- explain the `predev` hook and database initialization in README

## Testing
- `npm run type-check`
- `npm test` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6882b5fb93b483269fed4a8199ecf690