### PR TITLE
Use in-memory DB for init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Install dependencies with `npm install` (or `yarn`). Start the development serve
 npm run dev
 ```
 This command starts the Vite dev server.
+The `predev` step automatically runs `scripts/init-db.ts` to create a local database in memory, so no `.db` file is written to disk.
+
 In another terminal start your backend API (typically on port **3000**), for example:
 
 ```bash

--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -1,14 +1,13 @@
-import path from 'path'
-
-// Database initialization using ElectricSQL migrations
+// Database initialization using ElectricSQL migrations.
+// This script now uses an in-memory database so no file is created.
 
 async function run() {
   try {
     const { Database } = await import('wa-sqlite')
     const { initSQLite } = await import('../src/lib/sqlite')
 
-    const dbPath = path.resolve(__dirname, '../blue-ocean.db')
-    const db = new Database(dbPath)
+    // Use an in-memory SQLite database for local development
+    const db = new Database(':memory:')
     await initSQLite(db)
     await db.close()
     console.log('Database initialized')


### PR DESCRIPTION
## Summary
- update init-db script to use an in-memory SQLite database
- document new behaviour in README

## Testing
- `npm run type-check`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b5f2d2bc832683d2cc6f75f17bb6