### PR TITLE
Fix Node warning by using CJS postcss config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,5 @@
 
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
## Summary
- replace ES module syntax in `postcss.config.js` with CommonJS export

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883e791f1888326a382c8219f96053a