### PR TITLE
Add ESLint script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ After installation, run the test suite with:
 npm test
 ```
 
+### Linting
+
+Run ESLint using the shared configuration:
+
+```bash
+npm run lint
+```
+
 ## Brain prompt configuration
 
 The prompts and behaviour used by Aura are defined under `src/brain/`.  Each

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev:client": "vite",
     "build": "vite build",
     "test": "vitest run",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.27.3",


### PR DESCRIPTION
## Summary
- add `lint` script using eslint.config.js
- document linting command in README

## Testing
- `npm run lint` *(fails: reports lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e7929d488326b04017cc1210ed8f