### PR TITLE
Fix numbering of README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Ensure your backend is running at `VITE_API_BASE_URL`; the dev server will proxy
 API requests like `/projects` or `/subscription` to that address so the client
 can use relative URLs.
 
-### 5. Development dependencies
+### 6. Development dependencies
 
 Use the helper script to install all development packages, including the test runner **Vitest**:
 


### PR DESCRIPTION
## Summary
- correct the "Development dependencies" heading numbering in `README.md`

## Testing
- `grep -n '^### [0-9]' README.md`

------
https://chatgpt.com/codex/tasks/task_e_6883e7a2b45c8326971ef052ea845869