### PR TITLE
Use in-memory SQLite in main app init

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,7 @@ async function initDatabase() {
   try {
     const { Database } = await import('wa-sqlite')
     const { initSQLite } = await import('./lib/sqlite')
-    const db = new Database('blue-ocean.db')
+    const db = new Database(':memory:')
     await initSQLite(db)
     await db.close()
     if (import.meta.env.DEV) console.log('[Main] SQLite schema applied')


### PR DESCRIPTION
## Summary
- use `':memory:'` SQLite database in main app init instead of a disk file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e7a3e5dc8326adef929f63673be4