### PR TITLE
Fix package.json closing brace

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,5 +107,4 @@
     "node": ">=18"
   },
   "packageManager": "yarn@4.9.2+sha512.1fc009bc09d13cfd0e19efa44cbfc2b9cf6ca61482725eb35bbc5e257e093ebf4130db6dfe15d604ff4b79efd8e1e8e99b25fa7d0a6197c9f9826358d4d65c3c"
-  }
 }


### PR DESCRIPTION
## Summary
- remove stray closing brace so `package.json` ends correctly

## Testing
- `jq . package.json`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_6883eeb807c08326b1f1c9f4cd13d7d5