### PR TITLE
Switch to wa-sqlite Factory API

### DIFF
--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -3,13 +3,16 @@
 
 async function run() {
   try {
-    const { Database } = await import('wa-sqlite')
+    const SQLiteFactory = (await import('wa-sqlite/dist/wa-sqlite.mjs')).default
+    const SQLite = await import('wa-sqlite')
     const { initSQLite } = await import('../src/lib/sqlite')
 
     // Use an in-memory SQLite database for local development
-    const db = new Database(':memory:')
+    const module = await SQLiteFactory()
+    const sqlite3 = SQLite.Factory(module)
+    const db = await sqlite3.open_v2(':memory:')
     await initSQLite(db)
-    await db.close()
+    await sqlite3.close(db)
     console.log('Database initialized')
   } catch (err) {
     console.error('Failed to initialise database', err)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,11 +6,14 @@ import { loadBrainSettings } from './services/BrainSettingsService'
 
 async function initDatabase() {
   try {
-    const { Database } = await import('wa-sqlite')
+    const SQLiteFactory = (await import('wa-sqlite/dist/wa-sqlite.mjs')).default
+    const SQLite = await import('wa-sqlite')
     const { initSQLite } = await import('./lib/sqlite')
-    const db = new Database(':memory:')
+    const module = await SQLiteFactory()
+    const sqlite3 = SQLite.Factory(module)
+    const db = await sqlite3.open_v2(':memory:')
     await initSQLite(db)
-    await db.close()
+    await sqlite3.close(db)
     if (import.meta.env.DEV) console.log('[Main] SQLite schema applied')
   } catch (err) {
     console.error('[Main] Failed to initialise SQLite', err)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import path from "path"
 import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import { defineConfig } from "vitest/config"
 import * as dotenv from "dotenv"
 
 dotenv.config()


### PR DESCRIPTION
## Summary
- update SQLite initialization in the database init script
- use wa-sqlite Factory API in the React entry point
- adjust Vite config to use vitest types

## Testing
- `npm install --silent`
- `npx tsc -p tsconfig.node.json`

------
https://chatgpt.com/codex/tasks/task_e_6883fd24ec6c8326b4bf21cd91222b37