### PR TITLE
Switch to wa-sqlite Factory API

### DIFF
--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -1,15 +1,20 @@
 // Database initialization using ElectricSQL migrations.
 // This script now uses an in-memory database so no file is created.
+/// <reference path="./wa-sqlite.d.ts" />
 
 async function run() {
   try {
-    const { Database } = await import('wa-sqlite')
+    const SQLiteModule = await import('wa-sqlite/dist/wa-sqlite.mjs') as any
+    const SQLiteFactory = SQLiteModule.default as (config?: object) => Promise<any>
+    const SQLite = await import('wa-sqlite')
     const { initSQLite } = await import('../src/lib/sqlite')
 
     // Use an in-memory SQLite database for local development
-    const db = new Database(':memory:')
+    const module = await SQLiteFactory()
+    const sqlite3 = SQLite.Factory(module)
+    const db = await sqlite3.open_v2(':memory:')
     await initSQLite(db)
-    await db.close()
+    await sqlite3.close(db)
     console.log('Database initialized')
   } catch (err) {
     console.error('Failed to initialise database', err)

--- a/scripts/wa-sqlite.d.ts
+++ b/scripts/wa-sqlite.d.ts
@@ -1,0 +1,4 @@
+declare module 'wa-sqlite/dist/wa-sqlite.mjs' {
+  function ModuleFactory(config?: object): Promise<any>
+  export default ModuleFactory
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,11 +6,15 @@ import { loadBrainSettings } from './services/BrainSettingsService'
 
 async function initDatabase() {
   try {
-    const { Database } = await import('wa-sqlite')
+    const SQLiteModule = await import('wa-sqlite/dist/wa-sqlite.mjs') as any
+    const SQLiteFactory = SQLiteModule.default as (config?: object) => Promise<any>
+    const SQLite = await import('wa-sqlite')
     const { initSQLite } = await import('./lib/sqlite')
-    const db = new Database(':memory:')
+    const module = await SQLiteFactory()
+    const sqlite3 = SQLite.Factory(module)
+    const db = await sqlite3.open_v2(':memory:')
     await initSQLite(db)
-    await db.close()
+    await sqlite3.close(db)
     if (import.meta.env.DEV) console.log('[Main] SQLite schema applied')
   } catch (err) {
     console.error('[Main] Failed to initialise SQLite', err)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import path from "path"
 import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import { defineConfig } from "vitest/config"
 import * as dotenv from "dotenv"
 
 dotenv.config()


### PR DESCRIPTION
## Summary
- update SQLite initialization in the database init script
- use wa-sqlite Factory API in the React entry point
- declare module for wa-sqlite factory for ts-node

## Testing
- `npx tsc -p tsconfig.node.json`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883fd24ec6c8326b4bf21cd91222b37