### PR TITLE
Fix: document electric-sql dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ When `npm run dev` starts it first executes the `predev` script defined in
 ```json
 "predev": "ts-node scripts/init-db.ts"
 ```
-The script depends on the `electric-sql` package. It loads `initSQLite` from
+The script depends on the `electric-sql` dependency for database initialization. It loads `initSQLite` from
 `src/lib/sqlite.ts` and sets up an
 in-memory SQLite database using `wa-sqlite`. All migrations are applied each
 time the dev server starts, so the database is recreated on every run. Restart


### PR DESCRIPTION
## Summary
- clarify that electric-sql is used for DB initialization

## Testing
- `npm test` *(fails: vitest not found)*
- `pnpm test` *(fails: vitest not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6885135cec148326bdb839904a2e5d15