### PR TITLE
Align wa-sqlite alias with electric-sql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "three": "^0.165.0",
         "uuid": "^11.1.0",
         "vaul": "^1.1.1",
-        "wa-sqlite": "https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/v0.9.14",
+        "wa-sqlite": "github:rhashimoto/wa-sqlite#v0.9.14",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -12372,8 +12372,7 @@
     },
     "node_modules/wa-sqlite": {
       "version": "0.9.14",
-      "resolved": "https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/v0.9.14",
-      "integrity": "sha512-wnre9ieS6FhA0vXtEru1SoCuY72mDvN9fVzNuaAU+0mmCyr2BiparVJKGSqrukIkWiqSbxpU3Zg+VPL5DEbR5A=="
+      "resolved": "git+ssh://git@github.com/rhashimoto/wa-sqlite.git#6dbe4f044502a7a285e815896f56304a808fe25b"
     },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "three": "^0.165.0",
     "uuid": "^11.1.0",
     "vaul": "^1.1.1",
-    "wa-sqlite": "https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/v0.9.14",
+    "wa-sqlite": "github:rhashimoto/wa-sqlite#v0.9.14",
     "zod": "^3.25.76"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- fix `wa-sqlite` dependency spec to use github alias
- regenerate `package-lock.json`

## Testing
- `npm test`
- `npm run lint` *(fails: 22 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6885166b7ca0832684f8fa23dbeb0a5c