### PR TITLE
Update README for SQLite and Waku

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 VITE_API_BASE_URL=http://localhost:3000
 VITE_OPENAI_API_KEY=
 VITE_ELEVENLABS_API_KEY=
-VITE_ELECTRIC_URL=http://localhost:5133
+VITE_WAKU_RELAY_URL=
 
 # Set to "true" to include the Pythagora logging script. When unset or "false",
 # utils.js is skipped and no requests to /logs are made.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Firebase values are required for authentication to work correctly.
 - During development the Vite server proxies API paths like `/projects`, `/subscription`, `/users`, and more to this URL.
 - `VITE_OPENAI_API_KEY` – OpenAI key used by the browser (optional)
 - `VITE_ELEVENLABS_API_KEY` – ElevenLabs key for voice features (optional)
-- `VITE_ELECTRIC_URL` – URL of the ElectricSQL backend (e.g., `http://localhost:5133`). Postgres typically listens on `5432`.
+- `VITE_WAKU_RELAY_URL` – address of a Waku relay for optional message sync (leave unset for offline use)
 - `VITE_FIREBASE_API_KEY` – Firebase project API key
 - `VITE_FIREBASE_AUTH_DOMAIN` – Firebase auth domain
 - `VITE_FIREBASE_PROJECT_ID` – Firebase project ID
@@ -79,18 +79,15 @@ Rails users can run:
 bundle exec rails s -p 3000
 ```
 
-### ElectricSQL
-Setting `VITE_ELECTRIC_URL` enables realtime sync through an [ElectricSQL](https://electric-sql.com/) backend.
-To run the server locally, install the Electric CLI and start it (see the [Quickstart guide](https://electric-sql.com/docs/quickstart)):
+### Local SQLite & Waku Messaging
+All application data is stored in a local SQLite database created by
+`scripts/init-db.ts` using `wa-sqlite`. No external database service is
+required, so the app can run completely offline.
 
-```bash
-npx electric-sql dev
-```
-
-This command spins up Electric and Postgres containers. Electric's websocket
-endpoint usually runs on port **5133** while Postgres listens on **5432**.
-Leave `VITE_ELECTRIC_URL` unset to disable sync. If the backend isn't running,
-the app may log repeated `ECONNRESET` errors as it attempts to connect.
+When network access is available you can optionally sync messages over
+[Waku](https://waku.org/). Start a Waku node and set `VITE_WAKU_RELAY_URL` in
+your `.env` file to the node's multiaddress. Leaving this variable unset keeps
+the app in offline mode and no network requests are made for messaging.
 
 ### 3. Firebase Console Setup
 1. Open the [Firebase console](https://console.firebase.google.com/) and navigate to **Authentication → Sign‑in method**.
@@ -118,12 +115,9 @@ In another terminal start your backend API (typically on port **3000**), for exa
 cd path/to/api && npm start
 ```
 
-Run the ElectricSQL service as well:
-
-```bash
-npx electric-sql dev
-```
-This starts Postgres on **5432** and Electric on **5133**.
+To keep the app completely offline simply skip any additional services.
+If you want to sync messages when online, start a Waku node and set
+`VITE_WAKU_RELAY_URL` in your `.env` file.
 
 ### 5. Database initialization
 When `npm run dev` starts it first executes the `predev` script defined in
@@ -132,7 +126,7 @@ When `npm run dev` starts it first executes the `predev` script defined in
 ```json
 "predev": "ts-node scripts/init-db.ts"
 ```
-The script depends on the `electric-sql` dependency for database initialization. It loads `initSQLite` from
+The script loads `initSQLite` from
 `src/lib/sqlite.ts` and sets up an
 in-memory SQLite database using `wa-sqlite`. All migrations are applied each
 time the dev server starts, so the database is recreated on every run. Restart

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,37 +1,6 @@
-name: 'electric_quickstart'
-
+version: '3'
 services:
-  postgres:
-    image: docker.io/postgres:16-alpine
-    environment:
-      POSTGRES_DB: electric
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+  waku:
+    image: wakuorg/nwaku:latest
     ports:
-      - '54321:5432'
-    tmpfs:
-      - /var/lib/postgresql/data
-      - /tmp
-    command:
-      - -c
-      - listen_addresses=*
-      - -c
-      - wal_level=logical
-    healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
-  electric:
-    image: docker.io/electricsql/electric:latest
-    environment:
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/electric?sslmode=disable
-      # Not suitable for production. Only use insecure mode in development or if you've otherwise secured the Electric API.
-      # See https://electric-sql.com/docs/guides/security
-      ELECTRIC_INSECURE: true
-    ports:
-      - '3000:3000'
-    depends_on:
-      postgres:
-        condition: service_healthy
+      - '60000:60000'


### PR DESCRIPTION
## Summary
- document new local SQLite storage and optional Waku messaging
- drop ElectricSQL/Postgres compose services
- add Waku relay env variable example

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688696393ff88326a4630c69553b58e9