### PR TITLE
Switch to wa-sqlite client

### DIFF
--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -4,16 +4,8 @@ import './wa-sqlite.d.ts'
 
 async function run() {
   try {
-    const SQLiteModule = await import('wa-sqlite/dist/wa-sqlite.mjs') as any
-    const SQLiteFactory = SQLiteModule.default as (config?: object) => Promise<any>
-    const SQLite = await import('wa-sqlite')
-    const { initSQLite } = await import('../src/lib/sqlite')
-
-    // Use an in-memory SQLite database for local development
-    const module = await SQLiteFactory()
-    const sqlite3 = SQLite.Factory(module)
-    const db = await sqlite3.open_v2(':memory:')
-    await initSQLite(db)
+    const { getConnection } = await import('../src/lib/db')
+    const { sqlite3, db } = await getConnection()
     await sqlite3.close(db)
     console.log('Database initialized')
   } catch (err) {

--- a/src/__tests__/brainSettings.test.ts
+++ b/src/__tests__/brainSettings.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 let store: Record<string, string> = {}
-vi.mock('../lib/electric', () => ({
-  electric: {
-    brain_settings: {
-      get: vi.fn((key: string) => Promise.resolve(store[key] ? { key, value: store[key] } : undefined)),
-      put: vi.fn(({ key, value }: { key: string; value: string }) => { store[key] = value; return Promise.resolve() })
-    }
-  }
+vi.mock('../lib/db', () => ({
+  get: vi.fn((sql: string, params: any[]) => {
+    const key = params[0]
+    return Promise.resolve(store[key] ? { value: store[key] } : undefined)
+  }),
+  run: vi.fn((sql: string, params: any[]) => {
+    const key = params[0]
+    const value = params[1]
+    store[key] = value
+    return Promise.resolve()
+  })
 }))
 
 import brain from '../brain/Brain'

--- a/src/hooks/useElectricSync.ts
+++ b/src/hooks/useElectricSync.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { ShapeStream, isChangeMessage } from '@electric-sql/client'
-import { electric } from '@/lib/electric'
+import { run } from '@/lib/db'
 import type { Project } from '@/types/project'
 import type { ChatMessage } from '@/types/chat'
 
@@ -66,9 +66,24 @@ export function useElectricSync() {
               const { operation } = msg.headers
               const row = msg.value as Project
               if (operation === 'insert' || operation === 'update') {
-                await electric.projects.put(row)
+                await run(
+                  'INSERT OR REPLACE INTO projects (id,name,icon,category,createdAt,updatedAt,profile,character,milestones,widgets,chatHistory) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+                  [
+                    row.id,
+                    row.name,
+                    row.icon,
+                    row.category,
+                    String(row.createdAt),
+                    String(row.updatedAt),
+                    JSON.stringify(row.profile),
+                    JSON.stringify(row.character),
+                    JSON.stringify(row.milestones),
+                    JSON.stringify(row.widgets),
+                    JSON.stringify(row.chatHistory)
+                  ]
+                )
               } else if (operation === 'delete') {
-                await electric.projects.delete(row.id)
+                await run('DELETE FROM projects WHERE id = ?', [row.id])
               }
             }
           }
@@ -102,9 +117,12 @@ export function useElectricSync() {
               const { operation } = msg.headers
               const row = msg.value as MessageRow
               if (operation === 'insert' || operation === 'update') {
-                await electric.messages.put(row)
+                await run(
+                  'INSERT OR REPLACE INTO messages (id, projectId, sender, text, timestamp) VALUES (?,?,?,?,?)',
+                  [row.id, row.projectId, row.sender, row.text, row.timestamp]
+                )
               } else if (operation === 'delete') {
-                await electric.messages.delete(row.id)
+                await run('DELETE FROM messages WHERE id = ?', [row.id])
               }
             }
           }
@@ -138,9 +156,12 @@ export function useElectricSync() {
               const { operation } = msg.headers
               const row = msg.value as SummaryRow
               if (operation === 'insert' || operation === 'update') {
-                await electric.summaries.put(row)
+                await run(
+                  'INSERT OR REPLACE INTO summaries (id, summary, createdAt) VALUES (?,?,?)',
+                  [row.id, row.summary, row.createdAt]
+                )
               } else if (operation === 'delete') {
-                await electric.summaries.delete(row.id)
+                await run('DELETE FROM summaries WHERE id = ?', [row.id])
               }
             }
           }
@@ -174,9 +195,12 @@ export function useElectricSync() {
             const { operation } = msg.headers
             const row = msg.value as TipRow
             if (operation === 'insert' || operation === 'update') {
-              await electric.tips.put(row)
+              await run(
+                'INSERT OR REPLACE INTO tips (id, projectId, tip, createdAt) VALUES (?,?,?,?)',
+                [row.id, row.projectId, row.tip, row.createdAt]
+              )
             } else if (operation === 'delete') {
-              await electric.tips.delete(row.id)
+              await run('DELETE FROM tips WHERE id = ?', [row.id])
             }
           }
         }
@@ -210,9 +234,12 @@ export function useElectricSync() {
               const { operation } = msg.headers
               const row = msg.value as BrainSettingsRow
               if (operation === 'insert' || operation === 'update') {
-                await electric.brain_settings.put(row)
+                await run(
+                  'INSERT OR REPLACE INTO brain_settings (key, value) VALUES (?,?)',
+                  [row.key, row.value]
+                )
               } else if (operation === 'delete') {
-                await electric.brain_settings.delete(row.key)
+                await run('DELETE FROM brain_settings WHERE key = ?', [row.key])
               }
             }
           }

--- a/src/hooks/useProjectStorage.ts
+++ b/src/hooks/useProjectStorage.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Project } from '@/types/project'
-import { electric } from '@/lib/electric'
+import { run, all, get } from '@/lib/db'
 import {
   getProjects as apiGetProjects,
   createProject as apiCreateProject,
@@ -12,6 +12,41 @@ import {
  * Stores projects in the local ElectricSQL database. On first load any
  * projects found in localStorage will be migrated into the database.
  */
+function rowToProject(row: any): Project {
+  return {
+    id: row.id,
+    name: row.name,
+    icon: row.icon,
+    category: row.category,
+    createdAt: new Date(row.createdAt),
+    updatedAt: new Date(row.updatedAt),
+    profile: row.profile ? JSON.parse(row.profile) : { vision: '', metrics: [], objective: '' },
+    character: row.character ? JSON.parse(row.character) : { role: '', level: 0, xp: 0, xpToNext: 0, jobPerk: '' },
+    milestones: row.milestones ? JSON.parse(row.milestones) : [],
+    widgets: row.widgets ? JSON.parse(row.widgets) : [],
+    chatHistory: row.chatHistory ? JSON.parse(row.chatHistory) : []
+  }
+}
+
+async function insertProject(project: Project) {
+  await run(
+    'INSERT OR REPLACE INTO projects (id,name,icon,category,createdAt,updatedAt,profile,character,milestones,widgets,chatHistory) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+    [
+      project.id,
+      project.name,
+      project.icon,
+      project.category,
+      project.createdAt.toString(),
+      project.updatedAt.toString(),
+      JSON.stringify(project.profile),
+      JSON.stringify(project.character),
+      JSON.stringify(project.milestones),
+      JSON.stringify(project.widgets),
+      JSON.stringify(project.chatHistory)
+    ]
+  )
+}
+
 export function useProjectStorage() {
   const [projects, setProjects] = useState<Project[]>([])
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null)
@@ -23,20 +58,23 @@ export function useProjectStorage() {
       try {
         const remote = await apiGetProjects()
         if (remote && remote.length > 0) {
-          await electric.projects.clear()
-          await electric.projects.bulkPut(remote)
+          await run('DELETE FROM projects')
+          for (const p of remote) {
+            await insertProject(p)
+          }
         }
       } catch (err) {
         console.error('Failed to fetch projects from API', err)
       }
 
-      let all = await electric.projects.toArray()
+      const allRows = await all<any>('SELECT * FROM projects')
+      let all = allRows.map(rowToProject)
       if (all.length === 0) {
         const stored = localStorage.getItem('lifepilot_projects')
         if (stored) {
           try {
             const parsed: Project[] = JSON.parse(stored)
-            await electric.projects.bulkAdd(parsed)
+            for (const p of parsed) await insertProject(p)
             all = parsed
             localStorage.removeItem('lifepilot_projects')
           } catch (e) {
@@ -45,11 +83,17 @@ export function useProjectStorage() {
         }
       }
 
-      const activeSetting = await electric.settings.get('activeProjectId')
+      const activeSetting = await get<{ value: string }>(
+        'SELECT value FROM settings WHERE key = ?',
+        ['activeProjectId']
+      )
       let activeId: string | null = null
       if (!activeSetting && localStorage.getItem('lifepilot_active_project')) {
         const id = localStorage.getItem('lifepilot_active_project') as string
-        await electric.settings.put({ key: 'activeProjectId', value: id })
+        await run('INSERT OR REPLACE INTO settings (key,value) VALUES (?,?)', [
+          'activeProjectId',
+          id
+        ])
         localStorage.removeItem('lifepilot_active_project')
         activeId = id
       } else {
@@ -58,7 +102,10 @@ export function useProjectStorage() {
 
       if (!activeId && all.length > 0) {
         activeId = all[0].id
-        await electric.settings.put({ key: 'activeProjectId', value: activeId })
+        await run('INSERT OR REPLACE INTO settings (key,value) VALUES (?,?)', [
+          'activeProjectId',
+          activeId
+        ])
       }
 
       setActiveProjectId(activeId)
@@ -71,14 +118,17 @@ export function useProjectStorage() {
 
   // helper to reload
   const reload = useCallback(async () => {
-    const all = await electric.projects.toArray()
-    setProjects(all)
+    const rows = await all<any>('SELECT * FROM projects')
+    setProjects(rows.map(rowToProject))
   }, [])
 
   const createProject = useCallback(async (projectData: Partial<Project>) => {
     const newProject = await apiCreateProject(projectData)
-    await electric.projects.add(newProject)
-    await electric.settings.put({ key: 'activeProjectId', value: newProject.id })
+    await insertProject(newProject)
+    await run('INSERT OR REPLACE INTO settings (key,value) VALUES (?,?)', [
+      'activeProjectId',
+      newProject.id
+    ])
     setActiveProjectId(newProject.id)
     reload()
     return newProject
@@ -86,24 +136,32 @@ export function useProjectStorage() {
 
   const updateProject = useCallback(async (projectId: string, updates: Partial<Project>) => {
     const updated = await apiUpdateProject(projectId, updates)
-    await electric.projects.put(updated)
+    await insertProject(updated)
     reload()
   }, [reload])
 
   const deleteProject = useCallback(async (projectId: string) => {
     await apiDeleteProject(projectId)
-    await electric.projects.delete(projectId)
-    const remaining = await electric.projects.toArray()
+    await run('DELETE FROM projects WHERE id = ?', [projectId])
+    const remainingRows = await all<any>('SELECT * FROM projects')
+    const remaining = remainingRows.map(rowToProject)
     if (activeProjectId === projectId) {
       const first = remaining[0]?.id ?? null
       setActiveProjectId(first)
-      if (first) await electric.settings.put({ key: 'activeProjectId', value: first })
+      if (first)
+        await run('INSERT OR REPLACE INTO settings (key,value) VALUES (?,?)', [
+          'activeProjectId',
+          first
+        ])
     }
     setProjects(remaining)
   }, [activeProjectId])
 
   const switchProject = useCallback(async (projectId: string) => {
-    await electric.settings.put({ key: 'activeProjectId', value: projectId })
+    await run('INSERT OR REPLACE INTO settings (key,value) VALUES (?,?)', [
+      'activeProjectId',
+      projectId
+    ])
     setActiveProjectId(projectId)
   }, [])
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,122 @@
+export interface SqliteConnection {
+  sqlite3: any
+  db: number
+}
+
+let connection: Promise<SqliteConnection> | null = null
+let SQLite: any
+
+async function openDatabase(): Promise<SqliteConnection> {
+  const SQLiteModule = await import('wa-sqlite/dist/wa-sqlite.mjs') as any
+  const SQLiteFactory = SQLiteModule.default as (config?: object) => Promise<any>
+  SQLite = await import('wa-sqlite')
+
+  const module = await SQLiteFactory()
+  const sqlite3 = SQLite.Factory(module)
+
+  let vfs: any
+  if (typeof navigator !== 'undefined' && (navigator as any).storage?.getDirectory) {
+    const { OriginPrivateFileSystemVFS } = await import('wa-sqlite/src/examples/OriginPrivateFileSystemVFS.js')
+    vfs = new OriginPrivateFileSystemVFS()
+  } else {
+    const { IDBBatchAtomicVFS } = await import('wa-sqlite/src/examples/IDBBatchAtomicVFS.js')
+    vfs = new IDBBatchAtomicVFS('lifepilot')
+  }
+  sqlite3.vfs_register(vfs, true)
+
+  const flags = SQLite.SQLITE_OPEN_CREATE | SQLite.SQLITE_OPEN_READWRITE
+  const db = await sqlite3.open_v2('lifepilot.db', flags, vfs.name)
+
+  await initializeSchema(sqlite3, db)
+  return { sqlite3, db }
+}
+
+async function initializeSchema(sqlite3: any, db: number) {
+  const statements = [
+    `CREATE TABLE IF NOT EXISTS projects (
+      id text primary key,
+      name text not null,
+      icon text not null,
+      category text not null,
+      createdAt text not null,
+      updatedAt text not null,
+      profile text,
+      character text,
+      milestones text,
+      widgets text,
+      chatHistory text
+    )`,
+    `CREATE TABLE IF NOT EXISTS messages (
+      id integer primary key autoincrement,
+      projectId text not null,
+      sender text not null,
+      text text,
+      timestamp text not null
+    )`,
+    `CREATE TABLE IF NOT EXISTS summaries (
+      id text primary key,
+      summary text not null,
+      createdAt text not null
+    )`,
+    `CREATE TABLE IF NOT EXISTS tips (
+      id text primary key,
+      projectId text not null,
+      tip text not null,
+      createdAt text not null
+    )`,
+    `CREATE TABLE IF NOT EXISTS settings (
+      key text primary key,
+      value text not null
+    )`,
+    `CREATE TABLE IF NOT EXISTS brain_settings (
+      key text primary key,
+      value text not null
+    )`
+  ]
+
+  for (const sql of statements) {
+    await sqlite3.exec(db, sql)
+  }
+}
+
+export async function getConnection(): Promise<SqliteConnection> {
+  if (!connection) connection = openDatabase()
+  return connection
+}
+
+export async function run(sql: string, params: any[] = []): Promise<void> {
+  const { sqlite3, db } = await getConnection()
+  const prepared = await sqlite3.prepare_v2(db, sql)
+  try {
+    sqlite3.bind_collection(prepared.stmt, params)
+    await sqlite3.step(prepared.stmt)
+  } finally {
+    await sqlite3.finalize(prepared.stmt)
+  }
+}
+
+export async function all<T = any>(sql: string, params: any[] = []): Promise<T[]> {
+  const { sqlite3, db } = await getConnection()
+  const prepared = await sqlite3.prepare_v2(db, sql)
+  const results: T[] = []
+  try {
+    sqlite3.bind_collection(prepared.stmt, params)
+    const columns = sqlite3.column_names(prepared.stmt)
+    while (await sqlite3.step(prepared.stmt) === SQLite.SQLITE_ROW) {
+      const row = sqlite3.row(prepared.stmt)
+      const obj: any = {}
+      columns.forEach((c: string, i: number) => {
+        obj[c] = row[i]
+      })
+      results.push(obj)
+    }
+  } finally {
+    await sqlite3.finalize(prepared.stmt)
+  }
+  return results
+}
+
+export async function get<T = any>(sql: string, params: any[] = []): Promise<T | undefined> {
+  const rows = await all<T>(sql, params)
+  return rows[0]
+}

--- a/src/lib/sqlite.ts
+++ b/src/lib/sqlite.ts
@@ -1,7 +1,5 @@
-import type { DbSchema } from 'electric-sql/client/model'
+import { getConnection } from './db'
 
-export async function initSQLite(db: any) {
-  const { electrify } = await import('electric-sql/node')
-  const { schema } = await import('../sqlite/migrations')
-  await electrify(db, schema as unknown as DbSchema<any>)
+export async function initSQLite() {
+  await getConnection()
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,16 +6,8 @@ import { loadBrainSettings } from './services/BrainSettingsService'
 
 async function initDatabase() {
   try {
-    const SQLiteModule = await import('wa-sqlite/dist/wa-sqlite.mjs') as any
-    const SQLiteFactory = SQLiteModule.default as (config?: object) => Promise<any>
-
-    const SQLite = await import('wa-sqlite')
     const { initSQLite } = await import('./lib/sqlite')
-    const module = await SQLiteFactory()
-    const sqlite3 = SQLite.Factory(module)
-    const db = await sqlite3.open_v2(':memory:')
-    await initSQLite(db)
-    await sqlite3.close(db)
+    await initSQLite()
     if (import.meta.env.DEV) console.log('[Main] SQLite schema applied')
   } catch (err) {
     console.error('[Main] Failed to initialise SQLite', err)

--- a/src/services/AuraMemoryService.ts
+++ b/src/services/AuraMemoryService.ts
@@ -1,4 +1,4 @@
-import { electric } from '@/lib/electric'
+import { run, all, get } from '@/lib/db'
 import type { ChatMessage } from '@/types/chat'
 
 interface ProactiveTip {
@@ -17,26 +17,29 @@ export class AuraMemoryService {
     projectId: string,
     message: { sender: 'user' | 'aura'; text: string; timestamp?: string }
   ) {
-    await electric.messages.add({
-      projectId,
-      sender: message.sender,
-      text: message.text,
-      timestamp: message.timestamp ?? new Date().toISOString()
-    })
+    await run(
+      'INSERT INTO messages (projectId, sender, text, timestamp) VALUES (?,?,?,?)',
+      [
+        projectId,
+        message.sender,
+        message.text,
+        message.timestamp ?? new Date().toISOString()
+      ]
+    )
     await this.summarizeIfNeeded(projectId)
   }
 
   /** get full array of all messages for a project */
   static async getConversation(projectId: string): Promise<ChatMessage[]> {
-    return await electric.messages
-      .where('projectId')
-      .equals(projectId)
-      .sortBy('timestamp')
+    return await all<ChatMessage>(
+      'SELECT id, projectId, sender, text, timestamp FROM messages WHERE projectId = ? ORDER BY timestamp',
+      [projectId]
+    )
   }
 
   /** wipe conversation for a project */
   static async clearConversation(projectId: string) {
-    await electric.messages.where('projectId').equals(projectId).delete()
+    await run('DELETE FROM messages WHERE projectId = ?', [projectId])
   }
 
   /**
@@ -46,11 +49,10 @@ export class AuraMemoryService {
   static async persistSummary(projectId: string) {
     const convo = await this.getConversation(projectId)
     const summary = await this.generateSummary(convo)
-    await electric.summaries.put({
-      id: projectId,
-      summary,
-      createdAt: new Date().toISOString()
-    })
+    await run(
+      'INSERT OR REPLACE INTO summaries (id, summary, createdAt) VALUES (?,?,?)',
+      [projectId, summary, new Date().toISOString()]
+    )
   }
 
   /** summarize old messages when over threshold */
@@ -61,13 +63,15 @@ export class AuraMemoryService {
     const excess = convo.length - this.MEMORY_THRESHOLD
     const toSummarize = convo.slice(0, excess)
     const summary = await this.generateSummary(toSummarize)
-    await electric.summaries.add({
-      id: crypto.randomUUID(),
-      summary,
-      createdAt: new Date().toISOString()
-    })
+    await run(
+      'INSERT INTO summaries (id, summary, createdAt) VALUES (?,?,?)',
+      [crypto.randomUUID(), summary, new Date().toISOString()]
+    )
     const ids = toSummarize.map((m: any) => m.id)
-    await electric.messages.bulkDelete(ids)
+    if (ids.length > 0) {
+      const placeholders = ids.map(() => '?').join(',')
+      await run(`DELETE FROM messages WHERE id IN (${placeholders})`, ids)
+    }
   }
 
   /** start periodic review of conversation summaries */
@@ -92,10 +96,10 @@ export class AuraMemoryService {
 
   /** fetch stored proactive tips */
   static async getProactiveTips(projectId: string): Promise<ProactiveTip[]> {
-    return await electric.tips
-      .where('projectId')
-      .equals(projectId)
-      .sortBy('createdAt')
+    return await all<ProactiveTip>(
+      'SELECT id, projectId, tip, createdAt FROM tips WHERE projectId = ? ORDER BY createdAt',
+      [projectId]
+    )
   }
 
   /** review summaries and store a tip */
@@ -105,12 +109,10 @@ export class AuraMemoryService {
     const summary = await this.generateSummary(convo)
     const tip = await this.generateTip(summary)
     if (!tip) return
-    await electric.tips.add({
-      id: crypto.randomUUID(),
-      projectId,
-      tip,
-      createdAt: new Date().toISOString()
-    })
+    await run(
+      'INSERT INTO tips (id, projectId, tip, createdAt) VALUES (?,?,?,?)',
+      [crypto.randomUUID(), projectId, tip, new Date().toISOString()]
+    )
   }
 
   /** helper to call OpenAI to summarize text */

--- a/src/services/BrainSettingsService.ts
+++ b/src/services/BrainSettingsService.ts
@@ -3,7 +3,7 @@ import type { CognitionConfig } from '@/brain/cognition'
 import type { BehaviorConfig } from '@/brain/behavior'
 import type { Skill } from '@/brain/skills'
 import { getFilterByName, getFilterName } from '@/brain/filters'
-import { electric } from '@/lib/electric'
+import { get, run } from '@/lib/db'
 
 export interface BrainSettingsData {
   cognition: CognitionConfig
@@ -24,7 +24,7 @@ function applyConfig(data: BrainSettingsData) {
 }
 
 export async function loadBrainSettings() {
-  const row = await electric.brain_settings.get(STORAGE_KEY)
+  const row = await get<{ value: string }>('SELECT value FROM brain_settings WHERE key = ?', [STORAGE_KEY])
   if (row?.value) {
     try {
       const data: BrainSettingsData = JSON.parse(row.value)
@@ -36,12 +36,12 @@ export async function loadBrainSettings() {
 }
 
 export async function saveBrainSettings(data: BrainSettingsData) {
-  await electric.brain_settings.put({ key: STORAGE_KEY, value: JSON.stringify(data) })
+  await run('INSERT OR REPLACE INTO brain_settings (key, value) VALUES (?, ?)', [STORAGE_KEY, JSON.stringify(data)])
   applyConfig(data)
 }
 
 export async function exportBrainSettings(): Promise<string> {
-  const row = await electric.brain_settings.get(STORAGE_KEY)
+  const row = await get<{ value: string }>('SELECT value FROM brain_settings WHERE key = ?', [STORAGE_KEY])
   if (row?.value) return row.value
   const defaults: BrainSettingsData = {
     cognition: brain.cognition,


### PR DESCRIPTION
## Summary
- implement persistent DB helper using wa-sqlite
- update services and hooks to use SQLite instead of Dexie
- simplify init scripts to open the new DB
- update unit tests for new DB API

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6886963790208326b630ea3c8f444f8a