### PR TITLE
Add configurable Waku relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 VITE_API_BASE_URL=http://localhost:3000
 VITE_OPENAI_API_KEY=
 VITE_ELEVENLABS_API_KEY=
+# Multiaddress of a Waku relay to bootstrap from (optional)
 VITE_WAKU_RELAY_URL=
 
 # Set to "true" to include the Pythagora logging script. When unset or "false",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Firebase values are required for authentication to work correctly.
 - `VITE_OPENAI_API_KEY` – OpenAI key used by the browser (optional)
 - `VITE_ELEVENLABS_API_KEY` – ElevenLabs key for voice features (optional)
 - `VITE_ENABLE_WAKU` – set to `true` to enable Waku peer-to-peer chat (optional)
-- `VITE_WAKU_RELAY_URL` – address of a Waku relay for optional message sync (leave unset for offline use)
+- `VITE_WAKU_RELAY_URL` – multiaddress of a Waku relay to bootstrap from (optional; defaults to public peers)
 - `VITE_FIREBASE_API_KEY` – Firebase project API key
 - `VITE_FIREBASE_AUTH_DOMAIN` – Firebase auth domain
 - `VITE_FIREBASE_PROJECT_ID` – Firebase project ID
@@ -87,8 +87,8 @@ required, so the app can run completely offline.
 
 When network access is available you can optionally sync messages over
 [Waku](https://waku.org/). Start a Waku node and set `VITE_WAKU_RELAY_URL` in
-your `.env` file to the node's multiaddress. Leaving this variable unset keeps
-the app in offline mode and no network requests are made for messaging.
+your `.env` file to the node's multiaddress. If the variable is omitted the
+client uses the public bootstrap peers provided by the Waku network.
 
 ### Waku Messaging
 Setting `VITE_ENABLE_WAKU` to `true` enables peer-to-peer chat via the
@@ -124,8 +124,9 @@ cd path/to/api && npm start
 ```
 
 To keep the app completely offline simply skip any additional services.
-If you want to sync messages when online, start a Waku node and set
-`VITE_WAKU_RELAY_URL` in your `.env` file.
+If Waku is enabled the client will connect to public bootstrap peers by default.
+Set `VITE_WAKU_RELAY_URL` to point at your own node if you prefer to use a
+specific relay.
 
 ### 5. Database initialization
 When `npm run dev` starts it first executes the `predev` script defined in

--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -12,10 +12,15 @@ import type { ChatMessage } from '@/types/chat'
 const CONTENT_TOPIC = '/lifepilot/1/chat'
 
 let node: LightNode | null = null
+const { VITE_WAKU_RELAY_URL } = import.meta.env
 
 export async function connect(): Promise<LightNode> {
   if (node) return node
-  node = await createLightNode({ defaultBootstrap: true })
+  node = await createLightNode(
+    VITE_WAKU_RELAY_URL
+      ? { bootstrapPeers: [VITE_WAKU_RELAY_URL] }
+      : { defaultBootstrap: true }
+  )
   await node.start()
   await waitForRemotePeer(node)
   return node


### PR DESCRIPTION
## Summary
- let `src/lib/waku.ts` read `VITE_WAKU_RELAY_URL`
- use the variable as a custom bootstrap peer when provided
- update documentation for the new behavior
- add `VITE_WAKU_RELAY_URL` comment in `.env.example`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886a0fd0da88326a7eb8f97537f0e45