### PR TITLE
Add default Waku enable flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ VITE_API_BASE_URL=http://localhost:3000
 VITE_OPENAI_API_KEY=
 VITE_ELEVENLABS_API_KEY=
 VITE_WAKU_RELAY_URL=
+VITE_ENABLE_WAKU=false
 
 # Set to "true" to include the Pythagora logging script. When unset or "false",
 # utils.js is skipped and no requests to /logs are made.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ required, so the app can run completely offline.
 
 When network access is available you can optionally sync messages over
 [Waku](https://waku.org/). Start a Waku node and set `VITE_WAKU_RELAY_URL` in
-your `.env` file to the node's multiaddress. Leaving this variable unset keeps
-the app in offline mode and no network requests are made for messaging.
+your `.env` file to the node's multiaddress and set `VITE_ENABLE_WAKU=true`.
+Leaving these variables unset keeps the app in offline mode and no network
+requests are made for messaging.
 
 ### Waku Messaging
 Setting `VITE_ENABLE_WAKU` to `true` enables peer-to-peer chat via the


### PR DESCRIPTION
## Summary
- set `VITE_ENABLE_WAKU=false` in `.env.example`
- clarify README instructions for enabling Waku messaging

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6886a101362483268755bb9245152496