### PR TITLE
Add trait management to CharacterSheet

### DIFF
--- a/src/components/rpg/CharacterSheet.tsx
+++ b/src/components/rpg/CharacterSheet.tsx
@@ -1,13 +1,16 @@
-import React, { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Progress } from '@/components/ui/progress';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Crown, Zap, Target, Heart, Sparkles } from 'lucide-react';
-import { useCharacter } from '@/hooks/useCharacter';
-import { SkillTree } from './SkillTree';
+import React, { useState, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Crown, Zap, Target, Heart, Sparkles, X } from 'lucide-react'
+import { useCharacter } from '@/hooks/useCharacter'
+import { useProjectStorage } from '@/hooks/useProjectStorage'
+import { SkillTree } from './SkillTree'
+import { TraitService } from '@/services/TraitService'
 
 const jobIcons = {
   'Strategist': Crown,
@@ -22,8 +25,32 @@ const jobPerks = {
 };
 
 export function CharacterSheet() {
-  const { character, isLoading, xpAnimation, levelUpAnimation } = useCharacter();
-  const [showFullSheet, setShowFullSheet] = useState(false);
+  const { character, isLoading, xpAnimation, levelUpAnimation } = useCharacter()
+  const { activeProject } = useProjectStorage()
+  const [showFullSheet, setShowFullSheet] = useState(false)
+  const [traits, setTraits] = useState<string[]>([])
+  const [newTrait, setNewTrait] = useState('')
+
+  useEffect(() => {
+    if (showFullSheet && activeProject) {
+      TraitService.getTraits(activeProject.id).then(setTraits)
+    }
+  }, [showFullSheet, activeProject])
+
+  const handleAddTrait = async () => {
+    if (!activeProject) return
+    const trait = newTrait.trim()
+    if (!trait) return
+    const updated = await TraitService.addTrait(activeProject.id, trait)
+    setTraits(updated)
+    setNewTrait('')
+  }
+
+  const handleRemoveTrait = async (trait: string) => {
+    if (!activeProject) return
+    const updated = await TraitService.removeTrait(activeProject.id, trait)
+    setTraits(updated)
+  }
 
   if (isLoading || !character) {
     return (
@@ -141,6 +168,46 @@ export function CharacterSheet() {
                     <Sparkles className="w-3 h-3 mr-1" />
                     {jobPerks[character.currentJob]}
                   </Badge>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Traits */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center space-x-2">
+                  <Zap className="w-6 h-6 text-purple-500" />
+                  <span>Traits</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-2 mb-4">
+                  {traits.map(trait => (
+                    <Badge
+                      key={trait}
+                      className="flex items-center gap-1 bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200"
+                    >
+                      <span>{trait}</span>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="w-4 h-4"
+                        onClick={() => handleRemoveTrait(trait)}
+                      >
+                        <X className="w-3 h-3" />
+                      </Button>
+                    </Badge>
+                  ))}
+                </div>
+                <div className="flex gap-2">
+                  <Input
+                    value={newTrait}
+                    onChange={e => setNewTrait(e.target.value)}
+                    onKeyDown={e => e.key === 'Enter' && handleAddTrait()}
+                    placeholder="Add trait"
+                    className="flex-1"
+                  />
+                  <Button size="sm" onClick={handleAddTrait}>Add</Button>
                 </div>
               </CardContent>
             </Card>

--- a/src/services/TraitService.ts
+++ b/src/services/TraitService.ts
@@ -1,0 +1,46 @@
+import { electric } from '@/lib/electric'
+
+/**
+ * Service for storing and retrieving character traits.
+ * Traits are persisted per project in the ElectricSQL settings table.
+ */
+export class TraitService {
+  private static key(projectId: string) {
+    return `traits_${projectId}`
+  }
+
+  static async getTraits(projectId: string): Promise<string[]> {
+    const row = await electric.settings.get(this.key(projectId))
+    if (row?.value) {
+      try {
+        return JSON.parse(row.value) as string[]
+      } catch {
+        return []
+      }
+    }
+    return []
+  }
+
+  static async addTrait(projectId: string, trait: string): Promise<string[]> {
+    const traits = await this.getTraits(projectId)
+    if (!traits.includes(trait)) {
+      const updated = [...traits, trait]
+      await electric.settings.put({
+        key: this.key(projectId),
+        value: JSON.stringify(updated)
+      })
+      return updated
+    }
+    return traits
+  }
+
+  static async removeTrait(projectId: string, trait: string): Promise<string[]> {
+    const traits = await this.getTraits(projectId)
+    const updated = traits.filter(t => t !== trait)
+    await electric.settings.put({
+      key: this.key(projectId),
+      value: JSON.stringify(updated)
+    })
+    return updated
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TraitService` for persisting traits per project
- extend `CharacterSheet` with trait chips section
- allow adding and removing traits through `TraitService`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886e2c8741c8326ada13b6e54da8e71