### PR TITLE
Remove unused Instagram tables

### DIFF
--- a/src/__tests__/migrations.test.ts
+++ b/src/__tests__/migrations.test.ts
@@ -6,8 +6,6 @@ describe('sqlite schema', () => {
     const tables = Object.keys(schema.tables).sort()
     expect(tables).toEqual([
       'brain_settings',
-      'ig_accounts',
-      'ig_content',
       'messages',
       'projects',
       'settings',

--- a/src/sqlite/migrations.ts
+++ b/src/sqlite/migrations.ts
@@ -64,23 +64,6 @@ export const schema: LocalDbSchema = {
         'tip text not null',
         'createdAt text not null'
       ]
-    },
-    ig_accounts: {
-      columns: [
-        'id text primary key',
-        'username text not null',
-        'followers integer not null',
-        'niche text',
-        'discoveredAt text not null'
-      ]
-    },
-    ig_content: {
-      columns: [
-        'id text primary key',
-        'accountId text not null',
-        'idea text not null',
-        'createdAt text not null'
-      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- drop `ig_accounts` and `ig_content` definitions from the schema
- update migration test expectations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68894557a97883268c4f9de9afaf6409