### PR TITLE
Refactor InstagramAgent to use common Waku topics

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -37,6 +37,7 @@ This document outlines the autonomous agents present in the project, their archi
 - **Technologies:**
   - Waku (LightNode, LightPush, LightSubscribe)
   - GPT-4 via OpenAI API
+  - Shared helpers in `src/lib/wakuTopics.ts`
 - **Status:** Active. Migrating from SQLite to full Waku-based design.
 - **Planned Features:**
   - Real caption scraping

--- a/src/agents/InstagramAgent.ts
+++ b/src/agents/InstagramAgent.ts
@@ -1,9 +1,10 @@
+import { disconnect, connect } from '../lib/waku'
 import {
-  LightNode,
-  createDecoder,
-  createEncoder,
-} from '@waku/sdk'
-import { connect } from '../lib/waku'
+  ACCOUNT_TOPIC,
+  IDEAS_TOPIC,
+  sendMessage,
+  subscribeToTopic,
+} from '../lib/wakuTopics'
 
 export interface Account {
   id: string
@@ -25,52 +26,37 @@ export interface ContentIdea {
  * Discovers accounts, analyses posts and stores daily content ideas.
  * Uses Waku peer-to-peer messaging with in-memory storage.
  */
-const ACCOUNTS_TOPIC = '/aura/instagram-agent/accounts/1/app'
-const IDEAS_TOPIC = '/aura/instagram-agent/ideas/1/app'
-
 export class InstagramAgent {
   private accounts: Account[] = []
   private ideas: ContentIdea[] = []
+  private subs: { unsubscribe: () => Promise<void> }[] = []
 
-  private constructor(private node: LightNode) {}
+  private constructor() {}
 
   static async create(): Promise<InstagramAgent> {
-    const node = await connect()
-    const agent = new InstagramAgent(node)
+    await connect()
+    const agent = new InstagramAgent()
     await agent.subscribe()
     return agent
   }
 
   private async publish(topic: string, data: object): Promise<void> {
-    const encoder = createEncoder({ contentTopic: topic })
-    const payload = new TextEncoder().encode(JSON.stringify(data))
-    await this.node.lightPush.send(encoder, { payload })
+    await sendMessage(topic, data)
   }
 
   private async subscribe() {
-    const accountDecoder = createDecoder(ACCOUNTS_TOPIC)
-    await this.node.filter.subscribe(accountDecoder, msg => {
-      if (!msg.payload) return
-      try {
-        const text = new TextDecoder().decode(msg.payload)
-        const data = JSON.parse(text) as Account
+    const accountSub = await subscribeToTopic<Account>(
+      ACCOUNT_TOPIC,
+      data => {
         this.accounts.push(data)
-      } catch (err) {
-        console.error('[InstagramAgent] failed to decode account', err)
       }
-    })
+    )
+    this.subs.push(accountSub)
 
-    const ideaDecoder = createDecoder(IDEAS_TOPIC)
-    await this.node.filter.subscribe(ideaDecoder, msg => {
-      if (!msg.payload) return
-      try {
-        const text = new TextDecoder().decode(msg.payload)
-        const data = JSON.parse(text) as ContentIdea
-        this.ideas.push(data)
-      } catch (err) {
-        console.error('[InstagramAgent] failed to decode idea', err)
-      }
+    const ideaSub = await subscribeToTopic<ContentIdea>(IDEAS_TOPIC, data => {
+      this.ideas.push(data)
     })
+    this.subs.push(ideaSub)
   }
 
   async discoverAccounts(niche: string): Promise<Account[]> {
@@ -105,6 +91,10 @@ export class InstagramAgent {
   }
 
   async close() {
-    await this.node.stop()
+    for (const sub of this.subs) {
+      await sub.unsubscribe()
+    }
+    this.subs = []
+    await disconnect()
   }
 }

--- a/src/lib/wakuTopics.ts
+++ b/src/lib/wakuTopics.ts
@@ -1,0 +1,33 @@
+import { createEncoder, createDecoder, DecodedMessage } from '@waku/sdk'
+import { connect } from './waku'
+
+export const ACCOUNT_TOPIC = '/aura/instagram-agent/accounts/1/app'
+export const IDEAS_TOPIC = '/aura/instagram-agent/ideas/1/app'
+
+export type MessageHandler<T = any> = (data: T, raw: DecodedMessage) => void
+
+export async function sendMessage(topic: string, payload: any): Promise<void> {
+  const node = await connect()
+  const encoder = createEncoder({ contentTopic: topic })
+  const bytes = new TextEncoder().encode(JSON.stringify(payload))
+  await node.lightPush.send(encoder, { payload: bytes })
+}
+
+export async function subscribeToTopic<T = any>(
+  topic: string,
+  handler: MessageHandler<T>
+) {
+  const node = await connect()
+  const decoder = createDecoder(topic)
+  const sub = await node.filter.subscribe(decoder, msg => {
+    if (!msg.payload) return
+    try {
+      const text = new TextDecoder().decode(msg.payload)
+      const data = JSON.parse(text) as T
+      handler(data, msg)
+    } catch (err) {
+      console.error('[wakuTopics] failed to decode message', err)
+    }
+  })
+  return sub
+}


### PR DESCRIPTION
## Summary
- add `wakuTopics` helper for sending and subscribing to custom Waku topics
- refactor `InstagramAgent` to rely on `wakuTopics`
- document the helper in `agents.md`

## Testing
- `./scripts/setup-dev.sh`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889458d47508326a6fc85ca73b77401