### PR TITLE
Add Waku topic tests

### DIFF
--- a/src/__tests__/InstagramAgent.test.ts
+++ b/src/__tests__/InstagramAgent.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const connect = vi.fn().mockResolvedValue({})
+const disconnect = vi.fn()
+
+const handlers: Record<string, any> = {}
+const sendMessage = vi.fn()
+const subscribeToTopic = vi.fn(async (topic: string, handler: any) => {
+  handlers[topic] = handler
+  return { unsubscribe: vi.fn() }
+})
+
+vi.mock('../lib/waku', () => ({ connect, disconnect }))
+vi.mock('../lib/wakuTopics', () => ({
+  ACCOUNT_TOPIC: '/account',
+  IDEAS_TOPIC: '/ideas',
+  sendMessage,
+  subscribeToTopic
+}))
+
+let InstagramAgent: any
+let ACCOUNT_TOPIC: string
+let IDEAS_TOPIC: string
+
+beforeEach(async () => {
+  const mod = await import('../agents/InstagramAgent')
+  InstagramAgent = mod.InstagramAgent
+  ;({ ACCOUNT_TOPIC, IDEAS_TOPIC } = await import('../lib/wakuTopics'))
+  connect.mockClear()
+  disconnect.mockClear()
+  sendMessage.mockClear()
+  subscribeToTopic.mockClear()
+  for (const k in handlers) delete handlers[k]
+})
+
+describe('InstagramAgent', () => {
+  it('connects and subscribes on create', async () => {
+    await InstagramAgent.create()
+    expect(connect).toHaveBeenCalled()
+    expect(subscribeToTopic).toHaveBeenCalledWith(ACCOUNT_TOPIC, expect.any(Function))
+    expect(subscribeToTopic).toHaveBeenCalledWith(IDEAS_TOPIC, expect.any(Function))
+  })
+
+  it('discovers accounts and publishes them', async () => {
+    const agent = await InstagramAgent.create()
+    const [acc] = await agent.discoverAccounts('fitness')
+    expect(acc.username).toContain('fitness')
+    expect(sendMessage).toHaveBeenCalledWith(ACCOUNT_TOPIC, acc)
+  })
+
+  it('analyzes account and suggests ideas', async () => {
+    const agent = await InstagramAgent.create()
+    const [acc] = await agent.discoverAccounts('art')
+    const hook = await agent.analyzeAccount(acc.id)
+    expect(hook).toContain(acc.id)
+    expect(sendMessage).toHaveBeenCalledWith(IDEAS_TOPIC, expect.objectContaining({ accountId: acc.id }))
+    const ideas = await agent.suggestDailyContent()
+    expect(ideas.length).toBe(1)
+    expect(ideas[0].accountId).toBe(acc.id)
+  })
+
+  it('cleans up subscriptions on close', async () => {
+    subscribeToTopic.mockResolvedValueOnce({ unsubscribe: vi.fn() })
+    subscribeToTopic.mockResolvedValueOnce({ unsubscribe: vi.fn() })
+    const agent = await InstagramAgent.create()
+    const unsub1 = (await subscribeToTopic.mock.results[0].value).unsubscribe
+    const unsub2 = (await subscribeToTopic.mock.results[1].value).unsubscribe
+    await agent.close()
+    expect(unsub1).toHaveBeenCalled()
+    expect(unsub2).toHaveBeenCalled()
+    expect(disconnect).toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/migrations.test.ts
+++ b/src/__tests__/migrations.test.ts
@@ -4,13 +4,14 @@ import { schema } from '../sqlite/migrations'
 describe('sqlite schema', () => {
   it('defines all required tables', () => {
     const tables = Object.keys(schema.tables).sort()
-    expect(tables).toEqual([
+    const expectedTables = [
       'brain_settings',
       'messages',
       'projects',
       'settings',
       'summaries',
       'tips'
-    ])
+    ]
+    expect(tables).toEqual(expectedTables)
   })
 })

--- a/src/__tests__/wakuTopics.test.ts
+++ b/src/__tests__/wakuTopics.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const send = vi.fn()
+const subscribe = vi.fn()
+
+vi.mock('../lib/waku', () => ({
+  connect: vi.fn().mockResolvedValue({
+    lightPush: { send },
+    filter: { subscribe }
+  })
+}))
+
+vi.mock('@waku/sdk', () => ({
+  createEncoder: vi.fn(({ contentTopic }) => ({ topic: contentTopic })),
+  createDecoder: vi.fn(topic => topic)
+}))
+
+let sendMessage: any
+let subscribeToTopic: any
+let connect: any
+let createEncoder: any
+let createDecoder: any
+
+beforeEach(async () => {
+  const mod = await import('../lib/wakuTopics')
+  sendMessage = mod.sendMessage
+  subscribeToTopic = mod.subscribeToTopic
+  const wakuMod: any = await import('../lib/waku')
+  connect = wakuMod.connect
+  const sdk: any = await import('@waku/sdk')
+  createEncoder = sdk.createEncoder
+  createDecoder = sdk.createDecoder
+  send.mockReset()
+  subscribe.mockReset()
+  createEncoder.mockClear()
+  createDecoder.mockClear()
+})
+
+describe('wakuTopics utility', () => {
+  it('sends messages via light push', async () => {
+    await sendMessage('topic', { a: 1 })
+    expect(connect).toHaveBeenCalled()
+    expect(createEncoder).toHaveBeenCalledWith({ contentTopic: 'topic' })
+    const bytes = new TextEncoder().encode(JSON.stringify({ a: 1 }))
+    expect(send).toHaveBeenCalledWith({ topic: 'topic' }, { payload: bytes })
+  })
+
+  it('subscribes to topics and decodes messages', async () => {
+    let capturedCallback: any
+    subscribe.mockImplementation((decoder: any, cb: any) => {
+      capturedCallback = cb
+      return Promise.resolve({ unsubscribe: vi.fn() })
+    })
+    const handler = vi.fn()
+    const sub = await subscribeToTopic('topic', handler)
+    expect(createDecoder).toHaveBeenCalledWith('topic')
+    const payloadObj = { hello: 'world' }
+    const payload = new TextEncoder().encode(JSON.stringify(payloadObj))
+    capturedCallback({ payload })
+    expect(handler).toHaveBeenCalledWith(payloadObj, { payload })
+    expect(typeof sub.unsubscribe).toBe('function')
+  })
+})

--- a/src/agents/InstagramAgent.ts
+++ b/src/agents/InstagramAgent.ts
@@ -65,7 +65,7 @@ export class InstagramAgent {
     const followers = Math.floor(Math.random() * 1000)
     const discoveredAt = new Date().toISOString()
     const account: Account = { id, username, followers, niche, discoveredAt }
-    await this.publish(ACCOUNTS_TOPIC, account)
+    await this.publish(ACCOUNT_TOPIC, account)
     this.accounts.push(account)
     return [account]
   }


### PR DESCRIPTION
## Summary
- update migrations test to use `expectedTables` list
- fix constant typo in `InstagramAgent`
- add unit tests for `wakuTopics` utilities
- add unit tests for `InstagramAgent`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688947bbcebc8326bbd9ce5e8bd88f6d