### PR TITLE
Add encrypted local config via WakuIdentity

### DIFF
--- a/src/__tests__/InstagramAgent.test.ts
+++ b/src/__tests__/InstagramAgent.test.ts
@@ -17,6 +17,9 @@ vi.mock('../lib/wakuTopics', () => ({
   sendMessage,
   subscribeToTopic
 }))
+vi.mock('../services/ConfigService', () => ({
+  loadConfig: vi.fn(async () => ({ openaiApiKey: '' }))
+}))
 
 let InstagramAgent: any
 let ACCOUNT_TOPIC: string

--- a/src/__tests__/voice.test.tsx
+++ b/src/__tests__/voice.test.tsx
@@ -4,6 +4,9 @@ import { renderHook, act } from '@testing-library/react'
 import React from 'react'
 import { useVoiceInput } from '../hooks/useVoiceInput'
 import { useTextToSpeech } from '../hooks/useTextToSpeech'
+vi.mock('../services/ConfigService', () => ({
+  loadConfig: vi.fn(async () => ({ elevenLabsApiKey: '' }))
+}))
 
 // mock SpeechRecognition
 let lastRec: FakeRec | null = null
@@ -42,7 +45,6 @@ describe('useTextToSpeech', () => {
     ;(global as any).SpeechSynthesisUtterance = function (this: any, text: string) {
       this.text = text
     }
-    process.env.VITE_ELEVENLABS_API_KEY = ''
     const { result } = renderHook(() => useTextToSpeech())
     await act(async () => {
       await result.current.speak('hello')

--- a/src/__tests__/widgets.test.js
+++ b/src/__tests__/widgets.test.js
@@ -1,16 +1,12 @@
-
 import { describe, it, expect, vi } from 'vitest'
 
-// Mock API client used by widget helpers
-const mockWidgets = [
-  { id: 'goals-progress', data: [{ id: 1, progress: 60 }] }
-]
+const mockWidgets = [{ id: 'goals-progress', data: [{ id: 1, progress: 60 }] }]
 
 vi.mock('../api/api', () => ({
   default: {
-    post: vi.fn((url: string, body: any) => {
+    post: vi.fn((url, body) => {
       if (url === '/widgets/generate') {
-        const active: string[] = body?.activeWidgets ?? []
+        const active = body?.activeWidgets ?? []
         const filtered = mockWidgets.filter(w => !active.includes(w.id))
         return Promise.resolve({ data: { widgets: filtered } })
       }
@@ -25,16 +21,15 @@ vi.mock('../api/api', () => ({
 }))
 
 import { generateWidgets, updateWidgets } from '../api/widgets'
+vi.mock('../services/ConfigService', () => ({
+  loadConfig: vi.fn(async () => ({ apiBaseUrl: '', openaiApiKey: '' }))
+}))
 
-// Basic localStorage mock for API module used in tests
-(global as any).localStorage = {
+globalThis.localStorage = {
   getItem: () => null,
   setItem: () => undefined,
   removeItem: () => undefined
 }
-
-// ensure no API key so fallback logic runs
-process.env.VITE_OPENAI_API_KEY = ''
 
 describe('generateWidgets', () => {
   it('returns goal widget when context mentions goals', async () => {
@@ -53,7 +48,7 @@ describe('generateWidgets', () => {
 describe('updateWidgets', () => {
   it('updates goal progress when context mentions goal', async () => {
     const widgets = [{ id: 'goals-progress', data: [{ id: 1, progress: 50 }] }]
-    const res = await updateWidgets('goal', widgets as any)
+    const res = await updateWidgets('goal', widgets)
     expect(res.widgets[0].data[0].progress).toBeGreaterThan(50)
   })
 })

--- a/src/agents/InstagramAgent.ts
+++ b/src/agents/InstagramAgent.ts
@@ -5,7 +5,7 @@ import {
   sendMessage,
   subscribeToTopic,
 } from '../lib/wakuTopics'
-import OpenAI from 'openai'
+import { loadConfig } from '@/services/ConfigService'
 
 export interface Account {
   id: string
@@ -31,7 +31,6 @@ export class InstagramAgent {
   private accounts: Account[] = []
   private ideas: ContentIdea[] = []
   private subs: { unsubscribe: () => Promise<void> }[] = []
-  private openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
 
   private constructor() {}
 
@@ -94,8 +93,9 @@ export class InstagramAgent {
     ]
   }
 
-  async analyzeAccount(accountId: string, captions: string[]): Promise<string> {
-    const apiKey = import.meta.env.VITE_OPENAI_API_KEY
+  async analyzeAccount(accountId: string, captions: string[] = []): Promise<string> {
+    const cfg = await loadConfig()
+    const apiKey = cfg?.openaiApiKey
     const prompt = captions.join('\n')
     let hook = `Hook for ${accountId}`
 

--- a/src/api/ai.ts
+++ b/src/api/ai.ts
@@ -1,12 +1,14 @@
 // Description: Process onboarding responses with AI to create enhanced life plan or project plan
 // Returns: { success: boolean, plan: any, message: string, usedFallback?: boolean }
 import { TraitService } from '@/services/TraitService'
+import { loadConfig } from '@/services/ConfigService'
 
 export const processOnboardingWithAI = async (responses: Record<string, any>, planType: 'life' | 'project') => {
   if (import.meta.env.DEV)
     console.log('AI API: Processing onboarding with AI', { planType, responseKeys: Object.keys(responses) });
 
-  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+  const cfg = await loadConfig()
+  const apiKey = cfg?.openaiApiKey
   if (!apiKey) {
     console.warn('AI API: Missing OpenAI API key');
     return { success: false, plan: null, message: 'Missing OpenAI API key', usedFallback: true };

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,12 +1,22 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import axios from 'axios';
+import { loadConfig } from '@/services/ConfigService'
 
-const baseURL = import.meta.env.VITE_API_BASE_URL;
-
+let baseURL = ''
 const api = axios.create({
   baseURL,
   timeout: 10000,
-});
+})
+
+loadConfig().then(cfg => {
+  baseURL = cfg?.apiBaseUrl || ''
+  api.defaults.baseURL = baseURL
+})
+
+export function setBaseURL(url: string) {
+  baseURL = url
+  api.defaults.baseURL = url
+}
 
 const isDev = import.meta.env.DEV;
 

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -5,6 +5,7 @@ import brain from '@/brain/Brain';
  * Returns the assistant's reply wrapped in an object with a `message` field.
  */
 import type { ChatContext } from '@/types/chat';
+import { loadConfig } from '@/services/ConfigService'
 
 export const sendChatMessage = async (message: string, context?: ChatContext) => {
   if (import.meta.env.DEV) console.log('sendChatMessage - Called with message:', message);
@@ -17,7 +18,8 @@ export const sendChatMessage = async (message: string, context?: ChatContext) =>
   try {
     if (import.meta.env.DEV) console.log('sendChatMessage - Preparing OpenAI request');
 
-    const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+    const cfg = await loadConfig()
+    const apiKey = cfg?.openaiApiKey;
     if (!apiKey) {
       throw new Error('Missing OpenAI API key');
     }

--- a/src/api/widgets.ts
+++ b/src/api/widgets.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import { loadConfig } from '@/services/ConfigService'
 
 // A static set of widgets used when OpenAI is unavailable
 const fallbackWidgets = [
@@ -194,7 +195,8 @@ export const generateWidgets = async (
     widgets: fallbackWidgets.filter(w => !activeWidgets.includes(w.id))
   });
 
-  if (!import.meta.env.VITE_API_BASE_URL) {
+  const cfg = await loadConfig()
+  if (!cfg?.apiBaseUrl) {
     return fallback();
   }
 
@@ -230,7 +232,8 @@ export const updateWidgets = async (context: string, widgets: any[]) => {
     return { widgets }
   }
 
-  if (!import.meta.env.VITE_API_BASE_URL) {
+  const cfg = await loadConfig()
+  if (!cfg?.apiBaseUrl) {
     return fallback()
   }
 

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -7,6 +7,7 @@ import { useProjectStorage } from '@/hooks/useProjectStorage';
 import { AuraMemoryService } from '@/services/AuraMemoryService';
 import { TraitService } from '@/services/TraitService';
 import { connect as connectWaku, send as sendWaku, listen as listenWaku } from '@/lib/waku';
+import { loadConfig } from '@/services/ConfigService';
 
 type AuraState = 'idle' | 'listening' | 'thinking' | 'speaking';
 
@@ -28,7 +29,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const { activeProject, updateProject } = useProjectStorage();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [proactiveTips, setProactiveTips] = useState<string[]>([]);
-  const enableWaku = import.meta.env.VITE_ENABLE_WAKU === 'true';
+  const [enableWaku, setEnableWaku] = useState(false);
+
+  useEffect(() => {
+    loadConfig().then(cfg => setEnableWaku(cfg?.enableWaku ?? false));
+  }, []);
 
   const activeWidgets = useMemo(() => activeProject?.widgets ?? [], [activeProject?.widgets]);
 

--- a/src/hooks/useTextToSpeech.ts
+++ b/src/hooks/useTextToSpeech.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react'
+import { loadConfig } from '@/services/ConfigService'
 
 export function useTextToSpeech() {
   const [isSpeaking, setIsSpeaking] = useState(false)
@@ -6,7 +7,8 @@ export function useTextToSpeech() {
   const speak = useCallback(async (text: string) => {
     if (!text) return
     try {
-      const apiKey = import.meta.env.VITE_ELEVENLABS_API_KEY
+      const cfg = await loadConfig()
+      const apiKey = cfg?.elevenLabsApiKey
 
       if (apiKey) {
         const voiceId = '21m00Tcm4TlvDq8ikWAM'

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback } from 'react'
+import { loadConfig } from '@/services/ConfigService'
 
 export function useVoiceInput() {
   const [isRecording, setIsRecording] = useState(false)
@@ -38,7 +39,8 @@ export function useVoiceInput() {
             formData.append('file', blob, 'recording.webm')
             formData.append('model', 'whisper-1')
 
-            const apiKey = import.meta.env.VITE_OPENAI_API_KEY
+            const cfg = await loadConfig()
+            const apiKey = cfg?.openaiApiKey
             if (!apiKey) throw new Error('Missing OpenAI API key')
 
             const res = await fetch('https://api.openai.com/v1/audio/transcriptions', {

--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -12,7 +12,12 @@ import type { ChatMessage } from '@/types/chat'
 const CONTENT_TOPIC = '/lifepilot/1/chat'
 
 let node: LightNode | null = null
-const { VITE_WAKU_RELAY_URL } = import.meta.env
+import { loadConfig } from '@/services/ConfigService'
+
+let VITE_WAKU_RELAY_URL: string | undefined
+loadConfig().then(cfg => {
+  VITE_WAKU_RELAY_URL = cfg?.wakuRelayUrl
+})
 
 export async function connect(): Promise<LightNode> {
   if (node) return node
@@ -30,6 +35,13 @@ export async function send(message: ChatMessage): Promise<void> {
   if (!node) throw new Error('Waku not connected')
   const encoder = createEncoder({ contentTopic: CONTENT_TOPIC })
   const payload = new TextEncoder().encode(JSON.stringify(message))
+  await node.lightPush.send(encoder, { payload })
+}
+
+export async function sendOnTopic(topic: string, data: any): Promise<void> {
+  if (!node) throw new Error('Waku not connected')
+  const encoder = createEncoder({ contentTopic: topic })
+  const payload = new TextEncoder().encode(JSON.stringify(data))
   await node.lightPush.send(encoder, { payload })
 }
 

--- a/src/lib/wakuTopics.ts
+++ b/src/lib/wakuTopics.ts
@@ -1,3 +1,6 @@
+import { connect } from './waku'
+import { createEncoder, createDecoder } from '@waku/sdk'
+
 export const wakuTopics = {
   chat: '/lifepilot/1/chat',
   instagramAccounts: '/aura/instagram-agent/accounts/1/app',
@@ -6,3 +9,29 @@ export const wakuTopics = {
 } as const;
 
 export type WakuTopic = typeof wakuTopics[keyof typeof wakuTopics];
+
+export async function sendMessage(topic: string, data: any) {
+  const node: any = await connect()
+  const encoder = createEncoder({ contentTopic: topic })
+  const payload = new TextEncoder().encode(JSON.stringify(data))
+  await node.lightPush.send(encoder, { payload })
+}
+
+export async function subscribeToTopic<T>(
+  topic: string,
+  handler: (data: T, raw: any) => void
+) {
+  const node: any = await connect()
+  const decoder = createDecoder(topic)
+  const sub = await node.filter.subscribe(decoder, (msg: any) => {
+    if (!msg.payload) return
+    try {
+      const text = new TextDecoder().decode(msg.payload)
+      const data = JSON.parse(text) as T
+      handler(data, msg)
+    } catch (err) {
+      console.error('[waku] failed to decode message', err)
+    }
+  })
+  return sub
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 import { loadBrainSettings } from './services/BrainSettingsService'
+import { ensureConfig } from './services/ConfigService'
+import { setBaseURL } from './api/api'
 
 async function initDatabase() {
   try {
@@ -31,9 +33,7 @@ if (import.meta.env.DEV) console.log('[Main] Starting React application...');
 if (import.meta.env.DEV) console.log('[Main] Environment variables:', {
   NODE_ENV: import.meta.env.NODE_ENV,
   DEV: import.meta.env.DEV,
-  PROD: import.meta.env.PROD,
-  VITE_OPENAI_API_KEY: import.meta.env.VITE_OPENAI_API_KEY ? 'Present' : 'Missing',
-  VITE_ELEVENLABS_API_KEY: import.meta.env.VITE_ELEVENLABS_API_KEY ? 'Present' : 'Missing'
+  PROD: import.meta.env.PROD
 });
 
 // Add error handling for script loading
@@ -61,7 +61,10 @@ window.addEventListener('unhandledrejection', (event) => {
 async function start() {
   try {
     await initDatabase()
+    const cfg = await ensureConfig()
+    setBaseURL(cfg.apiBaseUrl)
     await loadBrainSettings()
+    if (import.meta.env.DEV) console.log('[Main] Loaded config', cfg)
     if (import.meta.env.DEV) console.log('[Main] Creating React root...')
     const root = ReactDOM.createRoot(document.getElementById('root')!)
     if (import.meta.env.DEV) console.log('[Main] Root created successfully')

--- a/src/services/AuraMemoryService.ts
+++ b/src/services/AuraMemoryService.ts
@@ -1,5 +1,6 @@
 import { electric } from '@/lib/electric'
 import type { ChatMessage } from '@/types/chat'
+import { loadConfig } from './ConfigService'
 
 interface ProactiveTip {
   id: string
@@ -115,7 +116,8 @@ export class AuraMemoryService {
 
   /** helper to call OpenAI to summarize text */
   private static async generateSummary(messages: ChatMessage[]): Promise<string> {
-    const apiKey = import.meta.env.VITE_OPENAI_API_KEY
+    const cfg = await loadConfig()
+    const apiKey = cfg?.openaiApiKey
     const prompt = messages
       .map(m => `${m.sender}: ${m.text}`)
       .join('\n')
@@ -146,7 +148,8 @@ export class AuraMemoryService {
 
   /** call OpenAI to create a short suggestion based on a summary */
   private static async generateTip(summary: string): Promise<string> {
-    const apiKey = import.meta.env.VITE_OPENAI_API_KEY
+    const cfg = await loadConfig()
+    const apiKey = cfg?.openaiApiKey
     if (!apiKey) return ''
 
     try {

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -1,0 +1,102 @@
+export interface AppConfig {
+  apiBaseUrl: string
+  openaiApiKey: string
+  elevenLabsApiKey?: string
+  enableWaku?: boolean
+  wakuRelayUrl?: string
+}
+
+import { electric } from '@/lib/electric'
+import { WakuIdentityService } from './WakuIdentityService'
+import { connect, sendOnTopic } from '@/lib/waku'
+
+const STORAGE_KEY = 'app-config'
+
+async function getKey(secret: string): Promise<CryptoKey> {
+  const enc = new TextEncoder()
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey']
+  )
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt: enc.encode(secret), iterations: 100000, hash: 'SHA-256' },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+
+async function encrypt(text: string, secret: string): Promise<string> {
+  const key = await getKey(secret)
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const encoded = new TextEncoder().encode(text)
+  const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoded)
+  const payload = new Uint8Array(iv.length + cipher.byteLength)
+  payload.set(iv, 0)
+  payload.set(new Uint8Array(cipher), iv.length)
+  return btoa(String.fromCharCode(...payload))
+}
+
+async function decrypt(data: string, secret: string): Promise<string> {
+  const bytes = Uint8Array.from(atob(data), c => c.charCodeAt(0))
+  const iv = bytes.slice(0, 12)
+  const cipher = bytes.slice(12)
+  const key = await getKey(secret)
+  const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, cipher)
+  return new TextDecoder().decode(plain)
+}
+
+export async function loadConfig(): Promise<AppConfig | null> {
+  const identity = await WakuIdentityService.getIdentity()
+  if (!identity) return null
+  const row = await electric.settings.get(STORAGE_KEY)
+  if (!row?.value) return null
+  try {
+    const json = await decrypt(row.value, identity.id)
+    return JSON.parse(json) as AppConfig
+  } catch {
+    return null
+  }
+}
+
+export async function saveConfig(config: AppConfig): Promise<void> {
+  const identity = await WakuIdentityService.getIdentity()
+  if (!identity) throw new Error('Missing identity')
+  const json = JSON.stringify(config)
+  const encrypted = await encrypt(json, identity.id)
+  await electric.settings.put({ key: STORAGE_KEY, value: encrypted })
+  try {
+    await connect()
+    await sendOnTopic(`/aura/users/${identity.id}/config`, { data: encrypted })
+  } catch (err) {
+    console.warn('[Config] Failed to publish config to Waku', err)
+  }
+}
+
+export async function exportConfig(): Promise<string> {
+  const config = await loadConfig()
+  return JSON.stringify(config ?? {})
+}
+
+export async function importConfig(json: string): Promise<void> {
+  const data = JSON.parse(json) as AppConfig
+  await saveConfig(data)
+}
+
+export async function ensureConfig(): Promise<AppConfig> {
+  let cfg = await loadConfig()
+  if (!cfg) {
+    const apiBaseUrl = window.prompt('API base URL (e.g. http://localhost:3000)') || ''
+    const openaiApiKey = window.prompt('OpenAI API key') || ''
+    const elevenLabsApiKey = window.prompt('ElevenLabs API key (optional)') || undefined
+    const enableWaku = window.confirm('Enable Waku messaging?')
+    const wakuRelayUrl = window.prompt('Waku relay multiaddress (optional)') || undefined
+    cfg = { apiBaseUrl, openaiApiKey, elevenLabsApiKey, enableWaku, wakuRelayUrl }
+    await saveConfig(cfg)
+  }
+  return cfg
+}


### PR DESCRIPTION
## Summary
- add `ConfigService` for encrypted user configuration
- load config on startup and apply API base URL
- store config to Waku via `WakuIdentityService`
- replace `import.meta.env` references with config lookups
- provide tests with mocked config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68894d2969ac8326b6d68a881aabe82e