### PR TITLE
Implement Pinata IPFS storage for Instagram ideas

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -46,6 +46,12 @@ This document outlines the autonomous agents present in the project, their archi
   - Engagement simulations
   - Cross-platform idea mapping
 
+#### Pinata Setup
+1. Create an account on [Pinata](https://www.pinata.cloud/) and generate a JWT token.
+2. Add the token to a `.env` file as `VITE_PINATA_JWT=<your-token>`.
+   Tests can use the variable `PINATA_JWT`.
+3. Restart the dev server so the Instagram agent can upload ideas to IPFS.
+
 ---
 
 ## 🧪 Future Agent Ideas

--- a/src/__tests__/InstagramAgent.test.ts
+++ b/src/__tests__/InstagramAgent.test.ts
@@ -22,6 +22,10 @@ vi.mock('../lib/wakuTopics', () => ({
 vi.mock('../services/ConfigService', () => ({
   loadConfig: vi.fn(async () => ({ openaiApiKey: '' }))
 }))
+const uploadJson = vi.fn(async () => 'QmHash')
+vi.mock('../services/IpfsService', () => ({
+  IpfsService: { uploadJson }
+}))
 
 let InstagramAgent: any
 let ACCOUNT_TOPIC: string
@@ -58,10 +62,14 @@ describe('InstagramAgent', () => {
     const [acc] = await agent.discoverAccounts('art')
     const hook = await agent.analyzeAccount(acc.id)
     expect(hook).toContain(acc.id)
-    expect(sendMessage).toHaveBeenCalledWith(IDEAS_TOPIC, expect.objectContaining({ accountId: acc.id }))
+    expect(sendMessage).toHaveBeenCalledWith(
+      IDEAS_TOPIC,
+      expect.objectContaining({ accountId: acc.id, hash: 'QmHash' })
+    )
     const ideas = await agent.suggestDailyContent()
     expect(ideas.length).toBe(1)
     expect(ideas[0].accountId).toBe(acc.id)
+    expect(ideas[0].ipfsHash).toBe('QmHash')
   })
 
   it('cleans up subscriptions on close', async () => {

--- a/src/agents/InstagramAgent.ts
+++ b/src/agents/InstagramAgent.ts
@@ -6,6 +6,7 @@ import {
   subscribeToTopic,
 } from '../lib/wakuTopics'
 import { loadConfig } from '@/services/ConfigService'
+import { IpfsService } from '@/services/IpfsService'
 
 export interface Account {
   id: string
@@ -20,6 +21,7 @@ export interface ContentIdea {
   accountId: string
   idea: string
   createdAt: string
+  ipfsHash?: string
 }
 
 /**
@@ -132,8 +134,24 @@ export class InstagramAgent {
     const ideaId = crypto.randomUUID()
     const createdAt = new Date().toISOString()
     const idea: ContentIdea = { id: ideaId, accountId, idea: hook, createdAt }
-    await this.publish(IDEAS_TOPIC, idea)
-    this.ideas.push(idea)
+
+    let ipfsHash: string | null = null
+    try {
+      ipfsHash = await IpfsService.uploadJson(idea)
+    } catch (err) {
+      console.error('[InstagramAgent] IPFS upload failed', err)
+    }
+
+    if (ipfsHash) {
+      await this.publish(IDEAS_TOPIC, {
+        id: ideaId,
+        accountId,
+        hash: ipfsHash,
+        createdAt
+      })
+    }
+
+    this.ideas.push({ ...idea, ...(ipfsHash ? { ipfsHash } : {}) })
     return hook
   }
 

--- a/src/services/IpfsService.ts
+++ b/src/services/IpfsService.ts
@@ -1,0 +1,34 @@
+export class IpfsService {
+  private static readonly PINATA_URL =
+    'https://api.pinata.cloud/pinning/pinJSONToIPFS'
+
+  private static getJwt(): string | undefined {
+    return (
+      (typeof import.meta !== 'undefined' &&
+        (import.meta as any).env?.VITE_PINATA_JWT) ||
+      process.env.PINATA_JWT
+    )
+  }
+
+  static async uploadJson(data: object): Promise<string> {
+    const jwt = this.getJwt()
+    if (!jwt) throw new Error('Missing Pinata JWT')
+
+    const res = await fetch(this.PINATA_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwt}`
+      },
+      body: JSON.stringify({ pinataContent: data })
+    })
+
+    if (!res.ok) {
+      const text = await res.text()
+      throw new Error(`Pinata upload failed (${res.status}): ${text}`)
+    }
+
+    const json = await res.json()
+    return json.IpfsHash || json.ipfsHash
+  }
+}


### PR DESCRIPTION
## Summary
- add new `IpfsService` for Pinata uploads
- store generated Instagram ideas on IPFS and publish hash
- update tests for the new behaviour
- document Pinata setup steps in `agents.md`

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688a5491a9588326962f3577f9efbec0