### PR TITLE
Add Instagram engagement events

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -26,6 +26,7 @@ This document outlines the autonomous agents present in the project, their archi
   - Waku messages to:
     - `/aura/instagram-agent/accounts/1/app` (discovered accounts)
     - `/aura/instagram-agent/ideas/1/app` (GPT-generated content hooks)
+    - `/aura/instagram-agent/engagements/1/app` (like/comment events)
   - Hook ideas are generated via the OpenAI client and each one is published individually
 
 
@@ -43,8 +44,8 @@ This document outlines the autonomous agents present in the project, their archi
 
 - **Planned Features:**
   - Real caption scraping
-  - Engagement simulations
   - Cross-platform idea mapping
+  - Basic engagement events published on `/aura/instagram-agent/engagements/1/app`
 
 ---
 

--- a/src/__tests__/InstagramAgent.test.ts
+++ b/src/__tests__/InstagramAgent.test.ts
@@ -16,6 +16,7 @@ vi.mock('../lib/waku', () => ({ connect, disconnect }))
 vi.mock('../lib/wakuTopics', () => ({
   ACCOUNT_TOPIC: '/account',
   IDEAS_TOPIC: '/ideas',
+  ENGAGEMENT_TOPIC: '/engagements',
   sendMessage,
   subscribeToTopic
 }))
@@ -26,11 +27,12 @@ vi.mock('../services/ConfigService', () => ({
 let InstagramAgent: any
 let ACCOUNT_TOPIC: string
 let IDEAS_TOPIC: string
+let ENGAGEMENT_TOPIC: string
 
 beforeEach(async () => {
   const mod = await import('../agents/InstagramAgent')
   InstagramAgent = mod.InstagramAgent
-  ;({ ACCOUNT_TOPIC, IDEAS_TOPIC } = await import('../lib/wakuTopics'))
+  ;({ ACCOUNT_TOPIC, IDEAS_TOPIC, ENGAGEMENT_TOPIC } = await import('../lib/wakuTopics'))
   connect.mockClear()
   disconnect.mockClear()
   sendMessage.mockClear()
@@ -44,6 +46,7 @@ describe('InstagramAgent', () => {
     expect(connect).toHaveBeenCalled()
     expect(subscribeToTopic).toHaveBeenCalledWith(ACCOUNT_TOPIC, expect.any(Function))
     expect(subscribeToTopic).toHaveBeenCalledWith(IDEAS_TOPIC, expect.any(Function))
+    expect(subscribeToTopic).toHaveBeenCalledWith(ENGAGEMENT_TOPIC, expect.any(Function))
   })
 
   it('discovers accounts and publishes them', async () => {
@@ -62,6 +65,15 @@ describe('InstagramAgent', () => {
     const ideas = await agent.suggestDailyContent()
     expect(ideas.length).toBe(1)
     expect(ideas[0].accountId).toBe(acc.id)
+  })
+
+  it('publishes engagement events', async () => {
+    const agent = await InstagramAgent.create()
+    await agent.engage('acc1', 'Great!')
+    expect(sendMessage).toHaveBeenCalledWith(
+      ENGAGEMENT_TOPIC,
+      expect.objectContaining({ accountId: 'acc1', message: 'Great!' })
+    )
   })
 
   it('cleans up subscriptions on close', async () => {

--- a/src/agents/InstagramAgent.ts
+++ b/src/agents/InstagramAgent.ts
@@ -2,6 +2,7 @@ import { disconnect, connect } from '../lib/waku'
 import {
   ACCOUNT_TOPIC,
   IDEAS_TOPIC,
+  ENGAGEMENT_TOPIC,
   sendMessage,
   subscribeToTopic,
 } from '../lib/wakuTopics'
@@ -22,6 +23,14 @@ export interface ContentIdea {
   createdAt: string
 }
 
+export interface Engagement {
+  id: string
+  accountId: string
+  type: 'like' | 'comment'
+  message?: string
+  createdAt: string
+}
+
 /**
  * Basic autonomous Instagram agent.
  * Discovers accounts, analyses posts and stores daily content ideas.
@@ -30,6 +39,7 @@ export interface ContentIdea {
 export class InstagramAgent {
   private accounts: Account[] = []
   private ideas: ContentIdea[] = []
+  private engagements: Engagement[] = []
   private subs: { unsubscribe: () => Promise<void> }[] = []
 
   private constructor() {}
@@ -58,6 +68,14 @@ export class InstagramAgent {
       this.ideas.push(data)
     })
     this.subs.push(ideaSub)
+
+    const engagementSub = await subscribeToTopic<Engagement>(
+      ENGAGEMENT_TOPIC,
+      data => {
+        this.engagements.push(data)
+      }
+    )
+    this.subs.push(engagementSub)
   }
 
   async discoverAccounts(niche: string): Promise<Account[]> {
@@ -142,7 +160,15 @@ export class InstagramAgent {
   }
 
   async engage(accountId: string, message: string) {
-    // Placeholder for future engagement features
+    const engagement: Engagement = {
+      id: crypto.randomUUID(),
+      accountId,
+      type: message ? 'comment' : 'like',
+      message,
+      createdAt: new Date().toISOString(),
+    }
+    await this.publish(ENGAGEMENT_TOPIC, engagement)
+    this.engagements.push(engagement)
     console.log(`[InstagramAgent] engage ${accountId}: ${message}`)
   }
 

--- a/src/lib/wakuTopics.ts
+++ b/src/lib/wakuTopics.ts
@@ -11,6 +11,10 @@ export const wakuTopics = {
   userTraits: (pubkey: string) => `/aura/users/${pubkey}/traits`
 } as const;
 
+export const ACCOUNT_TOPIC = wakuTopics.instagramAccounts;
+export const IDEAS_TOPIC = wakuTopics.instagramIdeas;
+export const ENGAGEMENT_TOPIC = wakuTopics.instagramEngagements;
+
 export type WakuTopic = typeof wakuTopics[keyof typeof wakuTopics];
 
 export async function sendMessage(topic: string, data: any) {


### PR DESCRIPTION
## Summary
- export ENGAGEMENT_TOPIC constant
- publish engagement events in `InstagramAgent`
- handle engagements in agent subscription
- update docs for engagement events
- test engagement publishing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a5494309c8326a04d343f520c50a8