### PR TITLE
Add FiverrAgent with Waku topics

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -51,12 +51,17 @@ This document outlines the autonomous agents present in the project, their archi
    Tests can use the variable `PINATA_JWT`.
 3. Restart the dev server so the Instagram agent can upload ideas to IPFS.
 
+### 2. `FiverrAgent`
+
+- **Purpose:** Optimize your Fiverr profile, analyze top freelancers and update gigs automatically.
+- **Outputs:**
+  - `/aura/fiverr-agent/freelancers/1/app` (top freelancer data)
+  - `/aura/fiverr-agent/gigs/1/app` (gig updates)
+- **Status:** Prototype. Listens on the topics above and publishes placeholder data.
+
 ---
 
 ## 🧪 Future Agent Ideas
-
-### 2. `FiverrAgent` (Coming Soon)
-- **Goal:** Optimize your Fiverr profile, update gigs automatically, scrape high-performing freelancers, and suggest profitable services.
 
 ### 3. `YouTubeAgent`
 - **Goal:** Analyze your or others' videos to optimize thumbnails, titles, and scripts.

--- a/src/__tests__/FiverrAgent.test.ts
+++ b/src/__tests__/FiverrAgent.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const connect = vi.fn().mockResolvedValue({})
+const disconnect = vi.fn()
+
+const sendMessage = vi.fn()
+const subscribeToTopic = vi.fn(async () => ({ unsubscribe: vi.fn() }))
+
+vi.mock('../lib/waku', () => ({ connect, disconnect }))
+vi.mock('../lib/wakuTopics', () => ({
+  FIVERR_FREELANCERS_TOPIC: '/freelancers',
+  FIVERR_GIGS_TOPIC: '/gigs',
+  sendMessage,
+  subscribeToTopic
+}))
+
+let FiverrAgent: any
+let FIVERR_FREELANCERS_TOPIC: string
+let FIVERR_GIGS_TOPIC: string
+
+beforeEach(async () => {
+  const mod = await import('../agents/FiverrAgent')
+  FiverrAgent = mod.FiverrAgent
+  ;({ FIVERR_FREELANCERS_TOPIC, FIVERR_GIGS_TOPIC } = await import('../lib/wakuTopics'))
+  connect.mockClear()
+  disconnect.mockClear()
+  sendMessage.mockClear()
+  subscribeToTopic.mockClear()
+})
+
+describe('FiverrAgent', () => {
+  it('connects and subscribes on create', async () => {
+    await FiverrAgent.create()
+    expect(connect).toHaveBeenCalled()
+    expect(subscribeToTopic).toHaveBeenCalledWith(FIVERR_FREELANCERS_TOPIC, expect.any(Function))
+    expect(subscribeToTopic).toHaveBeenCalledWith(FIVERR_GIGS_TOPIC, expect.any(Function))
+  })
+})

--- a/src/agents/FiverrAgent.ts
+++ b/src/agents/FiverrAgent.ts
@@ -1,0 +1,85 @@
+import { connect, disconnect } from '../lib/waku'
+import {
+  FIVERR_FREELANCERS_TOPIC,
+  FIVERR_GIGS_TOPIC,
+  sendMessage,
+  subscribeToTopic
+} from '../lib/wakuTopics'
+
+export interface FreelancerInfo {
+  id: string
+  name: string
+  rating: number
+}
+
+export interface GigUpdate {
+  id: string
+  title: string
+  updatedAt: string
+}
+
+/**
+ * Basic Fiverr agent skeleton.
+ * Subscribes to freelancer and gig update topics and publishes placeholder data.
+ */
+export class FiverrAgent {
+  private freelancers: FreelancerInfo[] = []
+  private gigs: GigUpdate[] = []
+  private subs: { unsubscribe: () => Promise<void> }[] = []
+
+  private constructor() {}
+
+  static async create(): Promise<FiverrAgent> {
+    await connect()
+    const agent = new FiverrAgent()
+    await agent.subscribe()
+    return agent
+  }
+
+  private async publish(topic: string, data: object): Promise<void> {
+    await sendMessage(topic, data)
+  }
+
+  private async subscribe() {
+    const freelancerSub = await subscribeToTopic<FreelancerInfo>(
+      FIVERR_FREELANCERS_TOPIC,
+      data => {
+        this.freelancers.push(data)
+      }
+    )
+    this.subs.push(freelancerSub)
+
+    const gigsSub = await subscribeToTopic<GigUpdate>(FIVERR_GIGS_TOPIC, data => {
+      this.gigs.push(data)
+    })
+    this.subs.push(gigsSub)
+  }
+
+  async analyzeTopFreelancers(category: string): Promise<FreelancerInfo[]> {
+    const id = crypto.randomUUID()
+    const name = `${category}_freelancer`
+    const rating = 5
+    const info: FreelancerInfo = { id, name, rating }
+    await this.publish(FIVERR_FREELANCERS_TOPIC, info)
+    this.freelancers.push(info)
+    return [info]
+  }
+
+  async updateGigs(): Promise<GigUpdate[]> {
+    const id = crypto.randomUUID()
+    const title = `Gig ${this.gigs.length + 1}`
+    const updatedAt = new Date().toISOString()
+    const update: GigUpdate = { id, title, updatedAt }
+    await this.publish(FIVERR_GIGS_TOPIC, update)
+    this.gigs.push(update)
+    return [update]
+  }
+
+  async close() {
+    for (const sub of this.subs) {
+      await sub.unsubscribe()
+    }
+    this.subs = []
+    await disconnect()
+  }
+}

--- a/src/lib/wakuTopics.ts
+++ b/src/lib/wakuTopics.ts
@@ -7,6 +7,8 @@ export const wakuTopics = {
   instagramIdeas: '/aura/instagram-agent/ideas/1/app',
   instagramEngagements: '/aura/instagram-agent/engagements/1/app',
   instagramCaptions: '/aura/instagram-agent/captions/1/app',
+  fiverrFreelancers: '/aura/fiverr-agent/freelancers/1/app',
+  fiverrGigs: '/aura/fiverr-agent/gigs/1/app',
   userProfile: (pubkey: string) => `/aura/users/${pubkey}/profile`,
   userConfig: (pubkey: string) => `/aura/users/${pubkey}/config`,
   userTraits: (pubkey: string) => `/aura/users/${pubkey}/traits`
@@ -15,6 +17,8 @@ export const wakuTopics = {
 export const ACCOUNT_TOPIC = wakuTopics.instagramAccounts;
 export const IDEAS_TOPIC = wakuTopics.instagramIdeas;
 export const CAPTIONS_TOPIC = wakuTopics.instagramCaptions;
+export const FIVERR_FREELANCERS_TOPIC = wakuTopics.fiverrFreelancers;
+export const FIVERR_GIGS_TOPIC = wakuTopics.fiverrGigs;
 
 export type WakuTopic = typeof wakuTopics[keyof typeof wakuTopics];
 


### PR DESCRIPTION
## Summary
- implement `FiverrAgent` skeleton
- define Fiverr topics in Waku helper
- update agent docs
- add basic tests for FiverrAgent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a5feb1b6483269067f2d3fe633574