### PR TITLE
Add AuraGrowthAgent with progress reporting

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -51,18 +51,19 @@ This document outlines the autonomous agents present in the project, their archi
    Tests can use the variable `PINATA_JWT`.
 3. Restart the dev server so the Instagram agent can upload ideas to IPFS.
 
+### 2. `AuraGrowthAgent`
+- **Purpose:** Coordinates platform agents like InstagramAgent, listens to their result topics, and publishes aggregated progress.
+- **Outputs:** `/aura/growth-agent/progress/1/app`
+
 ---
 
 ## 🧪 Future Agent Ideas
 
-### 2. `FiverrAgent` (Coming Soon)
+### 1. `FiverrAgent` (Coming Soon)
 - **Goal:** Optimize your Fiverr profile, update gigs automatically, scrape high-performing freelancers, and suggest profitable services.
 
 ### 3. `YouTubeAgent`
 - **Goal:** Analyze your or others' videos to optimize thumbnails, titles, and scripts.
-
-### 4. `AuraGrowthAgent`
-- **Meta-agent** that coordinates other platform-specific agents, tracks goal completion, and adapts based on feedback.
 
 ---
 
@@ -77,6 +78,7 @@ These topics are listed in `src/lib/wakuTopics.ts`.
 | Content ideas       | `/aura/instagram-agent/ideas/1/app`              |
 | Scraped captions    | `/aura/instagram-agent/captions/1/app`           |
 | Engagement events   | `/aura/instagram-agent/engagements/1/app`        |
+| Progress updates    | `/aura/growth-agent/progress/1/app`              |
 | User profile        | `/aura/users/{pubkey}/profile`                   |
 | User config         | `/aura/users/{pubkey}/config`                    |
 | User traits         | `/aura/users/{pubkey}/traits`                    |

--- a/src/__tests__/AuraGrowthAgent.test.ts
+++ b/src/__tests__/AuraGrowthAgent.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const connect = vi.fn().mockResolvedValue({})
+const disconnect = vi.fn()
+const sendMessage = vi.fn()
+const handlers: Record<string, any> = {}
+const subscribeToTopic = vi.fn(async (topic: string, handler: any) => {
+  handlers[topic] = handler
+  return { unsubscribe: vi.fn() }
+})
+
+const runDailyCycle = vi.fn(async () => {})
+const closeInstagram = vi.fn()
+const InstagramAgent = { create: vi.fn(async () => ({ runDailyCycle, close: closeInstagram })) }
+
+vi.mock('../lib/waku', () => ({ connect, disconnect }))
+vi.mock('../lib/wakuTopics', () => ({
+  ACCOUNT_TOPIC: '/account',
+  IDEAS_TOPIC: '/ideas',
+  PROGRESS_TOPIC: '/progress',
+  sendMessage,
+  subscribeToTopic
+}))
+vi.mock('../agents/InstagramAgent', () => ({ InstagramAgent }))
+
+let AuraGrowthAgent: any
+let PROGRESS_TOPIC: string
+let ACCOUNT_TOPIC: string
+let IDEAS_TOPIC: string
+
+beforeEach(async () => {
+  const mod = await import('../agents/AuraGrowthAgent')
+  AuraGrowthAgent = mod.AuraGrowthAgent
+  ;({ PROGRESS_TOPIC, ACCOUNT_TOPIC, IDEAS_TOPIC } = await import('../lib/wakuTopics'))
+  connect.mockClear()
+  disconnect.mockClear()
+  sendMessage.mockClear()
+  subscribeToTopic.mockClear()
+  InstagramAgent.create.mockClear()
+  runDailyCycle.mockClear()
+  closeInstagram.mockClear()
+  for (const k in handlers) delete handlers[k]
+})
+
+describe('AuraGrowthAgent', () => {
+  it('connects and subscribes on create', async () => {
+    await AuraGrowthAgent.create()
+    expect(connect).toHaveBeenCalled()
+    expect(subscribeToTopic).toHaveBeenCalledWith(ACCOUNT_TOPIC, expect.any(Function))
+    expect(subscribeToTopic).toHaveBeenCalledWith(IDEAS_TOPIC, expect.any(Function))
+  })
+
+  it('triggers Instagram agent and publishes progress', async () => {
+    const agent = await AuraGrowthAgent.create()
+    handlers[ACCOUNT_TOPIC]({ id: '1' })
+    handlers[IDEAS_TOPIC]({ id: 'a' })
+    await agent.triggerInstagramCycle('fitness')
+    expect(InstagramAgent.create).toHaveBeenCalled()
+    expect(runDailyCycle).toHaveBeenCalledWith('fitness')
+    expect(sendMessage).toHaveBeenCalledWith(
+      PROGRESS_TOPIC,
+      expect.objectContaining({ accounts: 1, ideas: 1 })
+    )
+  })
+
+  it('cleans up on close', async () => {
+    const agent = await AuraGrowthAgent.create()
+    const unsub1 = (await subscribeToTopic.mock.results[0].value).unsubscribe
+    const unsub2 = (await subscribeToTopic.mock.results[1].value).unsubscribe
+    await agent.close()
+    expect(unsub1).toHaveBeenCalled()
+    expect(unsub2).toHaveBeenCalled()
+    expect(closeInstagram).not.toHaveBeenCalled() // instagram not created yet
+    expect(disconnect).toHaveBeenCalled()
+  })
+})

--- a/src/agents/AuraGrowthAgent.ts
+++ b/src/agents/AuraGrowthAgent.ts
@@ -1,0 +1,70 @@
+import { InstagramAgent } from './InstagramAgent'
+import { connect, disconnect } from '../lib/waku'
+import {
+  ACCOUNT_TOPIC,
+  IDEAS_TOPIC,
+  PROGRESS_TOPIC,
+  sendMessage,
+  subscribeToTopic
+} from '../lib/wakuTopics'
+
+export interface ProgressReport {
+  accounts: number
+  ideas: number
+  timestamp: string
+}
+
+/**
+ * AuraGrowthAgent coordinates other platform agents such as InstagramAgent
+ * and publishes aggregated progress updates on a dedicated Waku topic.
+ */
+export class AuraGrowthAgent {
+  private instagram: InstagramAgent | null = null
+  private subs: { unsubscribe: () => Promise<void> }[] = []
+  private accounts: any[] = []
+  private ideas: any[] = []
+
+  private constructor() {}
+
+  static async create(): Promise<AuraGrowthAgent> {
+    await connect()
+    const agent = new AuraGrowthAgent()
+    await agent.subscribe()
+    return agent
+  }
+
+  private async subscribe() {
+    const accSub = await subscribeToTopic(ACCOUNT_TOPIC, data => {
+      this.accounts.push(data)
+    })
+    const ideaSub = await subscribeToTopic(IDEAS_TOPIC, data => {
+      this.ideas.push(data)
+    })
+    this.subs.push(accSub, ideaSub)
+  }
+
+  /** Spawn or reuse the Instagram agent and run its daily cycle */
+  async triggerInstagramCycle(niche: string): Promise<void> {
+    if (!this.instagram) {
+      this.instagram = await InstagramAgent.create()
+    }
+    await this.instagram.runDailyCycle(niche)
+    await this.publishProgress()
+  }
+
+  private async publishProgress() {
+    const report: ProgressReport = {
+      accounts: this.accounts.length,
+      ideas: this.ideas.length,
+      timestamp: new Date().toISOString()
+    }
+    await sendMessage(PROGRESS_TOPIC, report)
+  }
+
+  async close() {
+    if (this.instagram) await this.instagram.close()
+    for (const sub of this.subs) await sub.unsubscribe()
+    this.subs = []
+    await disconnect()
+  }
+}

--- a/src/lib/wakuTopics.ts
+++ b/src/lib/wakuTopics.ts
@@ -7,6 +7,7 @@ export const wakuTopics = {
   instagramIdeas: '/aura/instagram-agent/ideas/1/app',
   instagramEngagements: '/aura/instagram-agent/engagements/1/app',
   instagramCaptions: '/aura/instagram-agent/captions/1/app',
+  growthProgress: '/aura/growth-agent/progress/1/app',
   userProfile: (pubkey: string) => `/aura/users/${pubkey}/profile`,
   userConfig: (pubkey: string) => `/aura/users/${pubkey}/config`,
   userTraits: (pubkey: string) => `/aura/users/${pubkey}/traits`
@@ -15,6 +16,7 @@ export const wakuTopics = {
 export const ACCOUNT_TOPIC = wakuTopics.instagramAccounts;
 export const IDEAS_TOPIC = wakuTopics.instagramIdeas;
 export const CAPTIONS_TOPIC = wakuTopics.instagramCaptions;
+export const PROGRESS_TOPIC = wakuTopics.growthProgress;
 
 export type WakuTopic = typeof wakuTopics[keyof typeof wakuTopics];
 


### PR DESCRIPTION
## Summary
- add `AuraGrowthAgent` meta agent for coordinating platform agents
- provide new `growthProgress` Waku topic
- update documentation for AuraGrowthAgent and Waku topics
- test new coordination behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a5fec59888326b800f0f9000dc5ed