### PR TITLE
Add YouTubeAgent and Waku topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ The agent uses the following topics:
 - `/aura/instagram-agent/ideas/1/app`
 - `/aura/instagram-agent/engagements/1/app`
 
+## YouTube Agent
+
+The `YouTubeAgent` module in `src/agents/YouTubeAgent.ts` publishes video
+analysis on dedicated Waku topics defined in `src/lib/wakuTopics.ts`.
+
+The agent uses the following topics:
+- `/aura/youtube-agent/titles/1/app`
+- `/aura/youtube-agent/thumbnails/1/app`
+- `/aura/youtube-agent/scripts/1/app`
+
 ## Brain prompt configuration
 
 The prompts and behaviour used by Aura are defined under `src/brain/`.  Each

--- a/agents.md
+++ b/agents.md
@@ -51,15 +51,23 @@ This document outlines the autonomous agents present in the project, their archi
    Tests can use the variable `PINATA_JWT`.
 3. Restart the dev server so the Instagram agent can upload ideas to IPFS.
 
+### 2. `YouTubeAgent`
+- **Purpose:** Analyze YouTube videos for better titles, thumbnails, and scripts.
+- **Inputs:**
+  - Video ID and metadata
+  - Thumbnail URL
+  - Transcript or script text
+- **Outputs:**
+  - `/aura/youtube-agent/titles/1/app` (published titles)
+  - `/aura/youtube-agent/thumbnails/1/app` (thumbnail data)
+  - `/aura/youtube-agent/scripts/1/app` (scripts or transcripts)
+
 ---
 
 ## 🧪 Future Agent Ideas
 
-### 2. `FiverrAgent` (Coming Soon)
+### 3. `FiverrAgent` (Coming Soon)
 - **Goal:** Optimize your Fiverr profile, update gigs automatically, scrape high-performing freelancers, and suggest profitable services.
-
-### 3. `YouTubeAgent`
-- **Goal:** Analyze your or others' videos to optimize thumbnails, titles, and scripts.
 
 ### 4. `AuraGrowthAgent`
 - **Meta-agent** that coordinates other platform-specific agents, tracks goal completion, and adapts based on feedback.
@@ -77,6 +85,9 @@ These topics are listed in `src/lib/wakuTopics.ts`.
 | Content ideas       | `/aura/instagram-agent/ideas/1/app`              |
 | Scraped captions    | `/aura/instagram-agent/captions/1/app`           |
 | Engagement events   | `/aura/instagram-agent/engagements/1/app`        |
+| Video titles        | `/aura/youtube-agent/titles/1/app`               |
+| Video thumbnails    | `/aura/youtube-agent/thumbnails/1/app`           |
+| Video scripts       | `/aura/youtube-agent/scripts/1/app`              |
 | User profile        | `/aura/users/{pubkey}/profile`                   |
 | User config         | `/aura/users/{pubkey}/config`                    |
 | User traits         | `/aura/users/{pubkey}/traits`                    |

--- a/src/__tests__/YouTubeAgent.test.ts
+++ b/src/__tests__/YouTubeAgent.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const connect = vi.fn().mockResolvedValue({})
+const disconnect = vi.fn()
+const handlers: Record<string, any> = {}
+const sendMessage = vi.fn()
+const subscribeToTopic = vi.fn(async (topic: string, handler: any) => {
+  handlers[topic] = handler
+  return { unsubscribe: vi.fn() }
+})
+
+vi.mock('../lib/waku', () => ({ connect, disconnect }))
+vi.mock('../lib/wakuTopics', () => ({
+  YT_TITLES_TOPIC: '/titles',
+  YT_THUMBNAILS_TOPIC: '/thumbs',
+  YT_SCRIPTS_TOPIC: '/scripts',
+  sendMessage,
+  subscribeToTopic
+}))
+
+let YouTubeAgent: any
+let YT_TITLES_TOPIC: string
+let YT_THUMBNAILS_TOPIC: string
+let YT_SCRIPTS_TOPIC: string
+
+beforeEach(async () => {
+  const mod = await import('../agents/YouTubeAgent')
+  YouTubeAgent = mod.YouTubeAgent
+  ;({ YT_TITLES_TOPIC, YT_THUMBNAILS_TOPIC, YT_SCRIPTS_TOPIC } = await import('../lib/wakuTopics'))
+  connect.mockClear()
+  disconnect.mockClear()
+  sendMessage.mockClear()
+  subscribeToTopic.mockClear()
+  for (const k in handlers) delete handlers[k]
+})
+
+describe('YouTubeAgent', () => {
+  it('connects and subscribes on create', async () => {
+    await YouTubeAgent.create()
+    expect(connect).toHaveBeenCalled()
+    expect(subscribeToTopic).toHaveBeenCalledWith(YT_TITLES_TOPIC, expect.any(Function))
+    expect(subscribeToTopic).toHaveBeenCalledWith(YT_THUMBNAILS_TOPIC, expect.any(Function))
+    expect(subscribeToTopic).toHaveBeenCalledWith(YT_SCRIPTS_TOPIC, expect.any(Function))
+  })
+
+  it('publishes and receives messages', async () => {
+    const agent = await YouTubeAgent.create()
+    await agent.analyzeVideo('v1', 'title', 'thumb', 'script')
+    expect(sendMessage).toHaveBeenCalledWith(YT_TITLES_TOPIC, expect.any(Object))
+    expect(sendMessage).toHaveBeenCalledWith(YT_THUMBNAILS_TOPIC, expect.any(Object))
+    expect(sendMessage).toHaveBeenCalledWith(YT_SCRIPTS_TOPIC, expect.any(Object))
+
+    const titleMsg = { id: '1', videoId: 'v1', title: 't', createdAt: 'now' }
+    handlers[YT_TITLES_TOPIC](titleMsg, {})
+    expect(agent.titles[0]).toEqual(titleMsg)
+
+    const thumbMsg = { id: '1', videoId: 'v1', thumbnail: 'th', createdAt: 'now' }
+    handlers[YT_THUMBNAILS_TOPIC](thumbMsg, {})
+    expect(agent.thumbnails[0]).toEqual(thumbMsg)
+
+    const scriptMsg = { id: '1', videoId: 'v1', script: 's', createdAt: 'now' }
+    handlers[YT_SCRIPTS_TOPIC](scriptMsg, {})
+    expect(agent.scripts[0]).toEqual(scriptMsg)
+  })
+})

--- a/src/agents/YouTubeAgent.ts
+++ b/src/agents/YouTubeAgent.ts
@@ -1,0 +1,90 @@
+import { connect, disconnect } from '../lib/waku'
+import {
+  YT_TITLES_TOPIC,
+  YT_THUMBNAILS_TOPIC,
+  YT_SCRIPTS_TOPIC,
+  sendMessage,
+  subscribeToTopic,
+} from '../lib/wakuTopics'
+
+export interface TitleMsg {
+  id: string
+  videoId: string
+  title: string
+  createdAt: string
+}
+
+export interface ThumbnailMsg {
+  id: string
+  videoId: string
+  thumbnail: string
+  createdAt: string
+}
+
+export interface ScriptMsg {
+  id: string
+  videoId: string
+  script: string
+  createdAt: string
+}
+
+export class YouTubeAgent {
+  titles: TitleMsg[] = []
+  thumbnails: ThumbnailMsg[] = []
+  scripts: ScriptMsg[] = []
+  private subs: { unsubscribe: () => Promise<void> }[] = []
+
+  private constructor() {}
+
+  static async create(): Promise<YouTubeAgent> {
+    await connect()
+    const agent = new YouTubeAgent()
+    await agent.subscribe()
+    return agent
+  }
+
+  private async publish(topic: string, data: object): Promise<void> {
+    await sendMessage(topic, data)
+  }
+
+  private async subscribe() {
+    const titleSub = await subscribeToTopic<TitleMsg>(YT_TITLES_TOPIC, data => {
+      this.titles.push(data)
+    })
+    this.subs.push(titleSub)
+
+    const thumbSub = await subscribeToTopic<ThumbnailMsg>(
+      YT_THUMBNAILS_TOPIC,
+      data => {
+        this.thumbnails.push(data)
+      }
+    )
+    this.subs.push(thumbSub)
+
+    const scriptSub = await subscribeToTopic<ScriptMsg>(YT_SCRIPTS_TOPIC, data => {
+      this.scripts.push(data)
+    })
+    this.subs.push(scriptSub)
+  }
+
+  async analyzeVideo(
+    videoId: string,
+    title: string,
+    thumbnail: string,
+    script: string
+  ): Promise<void> {
+    const id = crypto.randomUUID()
+    const createdAt = new Date().toISOString()
+    await this.publish(YT_TITLES_TOPIC, { id, videoId, title, createdAt })
+    await this.publish(YT_THUMBNAILS_TOPIC, { id, videoId, thumbnail, createdAt })
+    await this.publish(YT_SCRIPTS_TOPIC, { id, videoId, script, createdAt })
+  }
+
+  async close() {
+    for (const sub of this.subs) {
+      await sub.unsubscribe()
+    }
+    this.subs = []
+    await disconnect()
+  }
+}

--- a/src/lib/wakuTopics.ts
+++ b/src/lib/wakuTopics.ts
@@ -7,6 +7,9 @@ export const wakuTopics = {
   instagramIdeas: '/aura/instagram-agent/ideas/1/app',
   instagramEngagements: '/aura/instagram-agent/engagements/1/app',
   instagramCaptions: '/aura/instagram-agent/captions/1/app',
+  youtubeTitles: '/aura/youtube-agent/titles/1/app',
+  youtubeThumbnails: '/aura/youtube-agent/thumbnails/1/app',
+  youtubeScripts: '/aura/youtube-agent/scripts/1/app',
   userProfile: (pubkey: string) => `/aura/users/${pubkey}/profile`,
   userConfig: (pubkey: string) => `/aura/users/${pubkey}/config`,
   userTraits: (pubkey: string) => `/aura/users/${pubkey}/traits`
@@ -15,6 +18,9 @@ export const wakuTopics = {
 export const ACCOUNT_TOPIC = wakuTopics.instagramAccounts;
 export const IDEAS_TOPIC = wakuTopics.instagramIdeas;
 export const CAPTIONS_TOPIC = wakuTopics.instagramCaptions;
+export const YT_TITLES_TOPIC = wakuTopics.youtubeTitles;
+export const YT_THUMBNAILS_TOPIC = wakuTopics.youtubeThumbnails;
+export const YT_SCRIPTS_TOPIC = wakuTopics.youtubeScripts;
 
 export type WakuTopic = typeof wakuTopics[keyof typeof wakuTopics];
 


### PR DESCRIPTION
## Summary
- implement `YouTubeAgent` for analyzing YouTube videos
- define new Waku topics for YouTube messages
- document the new agent and topics
- add tests for `YouTubeAgent`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a5feb470483268df46b830591c768