### PR TITLE
Add IdeaMapper service

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -72,6 +72,12 @@ This document outlines the autonomous agents present in the project, their archi
   - `/aura/fiverr-agent/gigs/1/app` (gig updates)
 - **Status:** Prototype. Listens on the topics above and publishes placeholder data.
 
+### 3. `IdeaMapper`
+- **Purpose:** Listens for Instagram content ideas and maps them to related Fiverr and YouTube ideas.
+- **Outputs:**
+  - `/aura/idea-mapper/mappings/1/app` (IPFS hash of the idea mapping)
+- **Technologies:** Waku messaging and IPFS via Pinata
+
 ---
 
 ## 🧪 Future Agent Ideas
@@ -105,6 +111,7 @@ These topics are listed in `src/lib/wakuTopics.ts`.
 | Video thumbnails    | `/aura/youtube-agent/thumbnails/1/app`           |
 | Video scripts       | `/aura/youtube-agent/scripts/1/app`              |
 | Progress updates    | `/aura/growth-agent/progress/1/app`              |
+| Idea mappings       | `/aura/idea-mapper/mappings/1/app`               |
 | User profile        | `/aura/users/{pubkey}/profile`                   |
 | User config         | `/aura/users/{pubkey}/config`                    |
 | User traits         | `/aura/users/{pubkey}/traits`                    |

--- a/src/__tests__/IdeaMapper.test.ts
+++ b/src/__tests__/IdeaMapper.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const connect = vi.fn().mockResolvedValue({})
+const disconnect = vi.fn()
+const handlers: Record<string, any> = {}
+const sendMessage = vi.fn()
+const subscribeToTopic = vi.fn(async (topic: string, handler: any) => {
+  handlers[topic] = handler
+  return { unsubscribe: vi.fn() }
+})
+const uploadJson = vi.fn(async () => 'QmHash')
+
+vi.mock('../lib/waku', () => ({ connect, disconnect }))
+vi.mock('../lib/wakuTopics', () => ({
+  IDEAS_TOPIC: '/ideas',
+  IDEA_MAPPINGS_TOPIC: '/mappings',
+  subscribeToTopic,
+  sendMessage
+}))
+vi.mock('../services/IpfsService', () => ({
+  IpfsService: { uploadJson }
+}))
+
+let IdeaMapper: any
+let IDEAS_TOPIC: string
+let IDEA_MAPPINGS_TOPIC: string
+
+beforeEach(async () => {
+  const mod = await import('../services/IdeaMapper')
+  IdeaMapper = mod.IdeaMapper
+  ;({ IDEAS_TOPIC, IDEA_MAPPINGS_TOPIC } = await import('../lib/wakuTopics'))
+  connect.mockClear()
+  disconnect.mockClear()
+  sendMessage.mockClear()
+  subscribeToTopic.mockClear()
+  uploadJson.mockClear()
+  for (const k in handlers) delete handlers[k]
+})
+
+describe('IdeaMapper', () => {
+  it('connects and subscribes on create', async () => {
+    await IdeaMapper.create()
+    expect(connect).toHaveBeenCalled()
+    expect(subscribeToTopic).toHaveBeenCalledWith(IDEAS_TOPIC, expect.any(Function))
+  })
+
+  it('generates and publishes mappings', async () => {
+    const mapper = await IdeaMapper.create()
+    await handlers[IDEAS_TOPIC]({ id: 'inst1' })
+    await Promise.resolve()
+    expect(uploadJson).toHaveBeenCalled()
+    expect(sendMessage).toHaveBeenCalledWith(
+      IDEA_MAPPINGS_TOPIC,
+      expect.objectContaining({ instagramIdeaId: 'inst1', hash: 'QmHash' })
+    )
+    expect(mapper.mappings[0].instagramIdeaId).toBe('inst1')
+    expect(mapper.mappings[0].ipfsHash).toBe('QmHash')
+  })
+
+  it('cleans up on close', async () => {
+    subscribeToTopic.mockResolvedValueOnce({ unsubscribe: vi.fn() })
+    const mapper = await IdeaMapper.create()
+    const unsub = (await subscribeToTopic.mock.results[0].value).unsubscribe
+    await mapper.close()
+    expect(unsub).toHaveBeenCalled()
+    expect(disconnect).toHaveBeenCalled()
+  })
+})

--- a/src/lib/wakuTopics.ts
+++ b/src/lib/wakuTopics.ts
@@ -13,6 +13,7 @@ export const wakuTopics = {
   growthProgress: '/aura/growth-agent/progress/1/app',
   fiverrFreelancers: '/aura/fiverr-agent/freelancers/1/app',
   fiverrGigs: '/aura/fiverr-agent/gigs/1/app',
+  ideaMappings: '/aura/idea-mapper/mappings/1/app',
   userProfile: (pubkey: string) => `/aura/users/${pubkey}/profile`,
   userConfig: (pubkey: string) => `/aura/users/${pubkey}/config`,
   userTraits: (pubkey: string) => `/aura/users/${pubkey}/traits`
@@ -28,6 +29,7 @@ export const YT_SCRIPTS_TOPIC = wakuTopics.youtubeScripts;
 export const PROGRESS_TOPIC = wakuTopics.growthProgress;
 export const FIVERR_FREELANCERS_TOPIC = wakuTopics.fiverrFreelancers;
 export const FIVERR_GIGS_TOPIC = wakuTopics.fiverrGigs;
+export const IDEA_MAPPINGS_TOPIC = wakuTopics.ideaMappings;
 
 export type WakuTopic = typeof wakuTopics[keyof typeof wakuTopics];
 

--- a/src/services/IdeaMapper.ts
+++ b/src/services/IdeaMapper.ts
@@ -1,0 +1,73 @@
+import { connect, disconnect } from '../lib/waku'
+import {
+  IDEAS_TOPIC,
+  IDEA_MAPPINGS_TOPIC,
+  subscribeToTopic,
+  sendMessage
+} from '../lib/wakuTopics'
+import { IpfsService } from './IpfsService'
+
+export interface IdeaMapping {
+  id: string
+  instagramIdeaId: string
+  fiverrIdea: string
+  youtubeIdea: string
+  createdAt: string
+  ipfsHash?: string
+}
+
+export class IdeaMapper {
+  mappings: IdeaMapping[] = []
+  private subs: { unsubscribe: () => Promise<void> }[] = []
+
+  private constructor() {}
+
+  static async create(): Promise<IdeaMapper> {
+    await connect()
+    const mapper = new IdeaMapper()
+    await mapper.subscribe()
+    return mapper
+  }
+
+  private async subscribe() {
+    const sub = await subscribeToTopic(IDEAS_TOPIC, data => {
+      void this.handleInstagramIdea(data)
+    })
+    this.subs.push(sub)
+  }
+
+  private async handleInstagramIdea(idea: any) {
+    const id = crypto.randomUUID()
+    const createdAt = new Date().toISOString()
+    const mapping: IdeaMapping = {
+      id,
+      instagramIdeaId: idea.id,
+      fiverrIdea: `Gig inspired by ${idea.id}`,
+      youtubeIdea: `Video idea inspired by ${idea.id}`,
+      createdAt
+    }
+
+    try {
+      const hash = await IpfsService.uploadJson(mapping)
+      mapping.ipfsHash = hash
+      await sendMessage(IDEA_MAPPINGS_TOPIC, {
+        id,
+        instagramIdeaId: idea.id,
+        hash,
+        createdAt
+      })
+    } catch (err) {
+      console.error('[IdeaMapper] failed to store mapping', err)
+    }
+
+    this.mappings.push(mapping)
+  }
+
+  async close() {
+    for (const sub of this.subs) {
+      await sub.unsubscribe()
+    }
+    this.subs = []
+    await disconnect()
+  }
+}


### PR DESCRIPTION
## Summary
- implement new IdeaMapper service that maps Instagram ideas to Fiverr and YouTube suggestions
- store mappings in IPFS and publish hashes over Waku
- expose new `/aura/idea-mapper/mappings/1/app` topic
- document IdeaMapper in agents doc
- test IdeaMapper workflow with mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a6f5bdfe883269d463d73624545ae