### PR TITLE
Add cron-based agent scheduler

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -90,6 +90,23 @@ This document outlines the autonomous agents present in the project, their archi
 
 ---
 
+## ⏰ Scheduling Agents
+
+Periodic tasks for each agent are orchestrated by the `AgentScheduler` module. It
+uses **node-cron** to run agent methods on a schedule. Results are still
+pushed to the same Waku topics listed below. To start the scheduler:
+
+```ts
+import { AgentScheduler } from './src/agents/AgentScheduler'
+
+const scheduler = new AgentScheduler()
+await scheduler.start()
+```
+
+Call `scheduler.stop()` to gracefully halt all cron jobs and close the agents.
+
+---
+
 ## 🛠 Agent Communication Protocol
 
 All agents communicate via Waku using the following topics:

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "lucide-react": "^0.460.0",
         "moment": "^2.30.1",
         "next-themes": "^0.4.3",
+        "node-cron": "^3.0.3",
         "openai": "^4.104.0",
         "pino": "^9.5.0",
         "react": "^18.3.1",
@@ -8309,6 +8310,27 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-domexception": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lucide-react": "^0.460.0",
     "moment": "^2.30.1",
     "next-themes": "^0.4.3",
+    "node-cron": "^3.0.3",
     "openai": "^4.104.0",
     "pino": "^9.5.0",
     "react": "^18.3.1",

--- a/src/__tests__/AgentScheduler.test.ts
+++ b/src/__tests__/AgentScheduler.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const schedule = vi.fn(() => ({ stop: vi.fn() }))
+vi.mock('node-cron', () => ({ default: { schedule } }))
+
+const runDailyCycle = vi.fn()
+const closeInstagram = vi.fn()
+const InstagramAgent = { create: vi.fn(async () => ({ runDailyCycle, close: closeInstagram })) }
+
+const updateGigs = vi.fn()
+const closeFiverr = vi.fn()
+const FiverrAgent = { create: vi.fn(async () => ({ updateGigs, close: closeFiverr })) }
+
+const triggerInstagramCycle = vi.fn()
+const closeGrowth = vi.fn()
+const AuraGrowthAgent = { create: vi.fn(async () => ({ triggerInstagramCycle, close: closeGrowth })) }
+
+vi.mock('../agents/InstagramAgent', () => ({ InstagramAgent }))
+vi.mock('../agents/FiverrAgent', () => ({ FiverrAgent }))
+vi.mock('../agents/AuraGrowthAgent', () => ({ AuraGrowthAgent }))
+
+let AgentScheduler: any
+
+beforeEach(async () => {
+  const mod = await import('../agents/AgentScheduler')
+  AgentScheduler = mod.AgentScheduler
+  schedule.mockClear()
+  runDailyCycle.mockClear()
+  updateGigs.mockClear()
+  triggerInstagramCycle.mockClear()
+  closeInstagram.mockClear()
+  closeFiverr.mockClear()
+  closeGrowth.mockClear()
+})
+
+describe('AgentScheduler', () => {
+  it('schedules tasks on start', async () => {
+    const scheduler = new AgentScheduler()
+    await scheduler.start()
+    expect(InstagramAgent.create).toHaveBeenCalled()
+    expect(FiverrAgent.create).toHaveBeenCalled()
+    expect(AuraGrowthAgent.create).toHaveBeenCalled()
+    expect(schedule).toHaveBeenCalledWith('0 9 * * *', expect.any(Function))
+    expect(schedule).toHaveBeenCalledWith('0 */6 * * *', expect.any(Function))
+    expect(schedule).toHaveBeenCalledWith('0 10 * * *', expect.any(Function))
+  })
+
+  it('stops jobs and closes agents', async () => {
+    const job1 = { stop: vi.fn() }
+    const job2 = { stop: vi.fn() }
+    const job3 = { stop: vi.fn() }
+    schedule.mockReturnValueOnce(job1)
+    schedule.mockReturnValueOnce(job2)
+    schedule.mockReturnValueOnce(job3)
+    const scheduler = new AgentScheduler()
+    await scheduler.start()
+    await scheduler.stop()
+    expect(job1.stop).toHaveBeenCalled()
+    expect(job2.stop).toHaveBeenCalled()
+    expect(job3.stop).toHaveBeenCalled()
+    expect(closeInstagram).toHaveBeenCalled()
+    expect(closeFiverr).toHaveBeenCalled()
+    expect(closeGrowth).toHaveBeenCalled()
+  })
+})

--- a/src/agents/AgentScheduler.ts
+++ b/src/agents/AgentScheduler.ts
@@ -1,0 +1,60 @@
+import cron from 'node-cron'
+import { InstagramAgent } from './InstagramAgent'
+import { FiverrAgent } from './FiverrAgent'
+import { AuraGrowthAgent } from './AuraGrowthAgent'
+
+export interface ScheduledJob {
+  stop: () => void
+}
+
+/**
+ * AgentScheduler starts agents and runs their periodic tasks using cron
+ * expressions. All results continue to be pushed to Waku topics by the
+ * agents themselves.
+ */
+export class AgentScheduler {
+  private jobs: ScheduledJob[] = []
+  private instagram: InstagramAgent | null = null
+  private fiverr: FiverrAgent | null = null
+  private growth: AuraGrowthAgent | null = null
+
+  /** Start the scheduler and register default tasks */
+  async start(): Promise<void> {
+    this.instagram = await InstagramAgent.create()
+    this.fiverr = await FiverrAgent.create()
+    this.growth = await AuraGrowthAgent.create()
+
+    // Instagram content discovery once a day at 9am
+    this.jobs.push(
+      cron.schedule('0 9 * * *', async () => {
+        if (this.instagram) await this.instagram.runDailyCycle('fitness')
+      })
+    )
+
+    // Fiverr gig updates every 6 hours
+    this.jobs.push(
+      cron.schedule('0 */6 * * *', async () => {
+        if (this.fiverr) await this.fiverr.updateGigs()
+      })
+    )
+
+    // Aggregated progress after Instagram cycle at 10am
+    this.jobs.push(
+      cron.schedule('0 10 * * *', async () => {
+        if (this.growth) await this.growth.triggerInstagramCycle('fitness')
+      })
+    )
+  }
+
+  /** Stop all cron jobs and close agents */
+  async stop(): Promise<void> {
+    for (const job of this.jobs) job.stop()
+    this.jobs = []
+    if (this.instagram) await this.instagram.close()
+    if (this.fiverr) await this.fiverr.close()
+    if (this.growth) await this.growth.close()
+    this.instagram = null
+    this.fiverr = null
+    this.growth = null
+  }
+}


### PR DESCRIPTION
## Summary
- install `node-cron`
- create `AgentScheduler` to run agents on schedules
- document scheduling setup
- test scheduler logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a6f60396083268a4dca6fe9740957