### PR TITLE
Add agent messaging tests

### DIFF
--- a/src/__tests__/FiverrAgent.test.ts
+++ b/src/__tests__/FiverrAgent.test.ts
@@ -4,7 +4,11 @@ const connect = vi.fn().mockResolvedValue({})
 const disconnect = vi.fn()
 
 const sendMessage = vi.fn()
-const subscribeToTopic = vi.fn(async () => ({ unsubscribe: vi.fn() }))
+const handlers: Record<string, any> = {}
+const subscribeToTopic = vi.fn(async (topic: string, handler: any) => {
+  handlers[topic] = handler
+  return { unsubscribe: vi.fn() }
+})
 
 vi.mock('../lib/waku', () => ({ connect, disconnect }))
 vi.mock('../lib/wakuTopics', () => ({
@@ -26,6 +30,7 @@ beforeEach(async () => {
   disconnect.mockClear()
   sendMessage.mockClear()
   subscribeToTopic.mockClear()
+  for (const k in handlers) delete handlers[k]
 })
 
 describe('FiverrAgent', () => {
@@ -34,5 +39,36 @@ describe('FiverrAgent', () => {
     expect(connect).toHaveBeenCalled()
     expect(subscribeToTopic).toHaveBeenCalledWith(FIVERR_FREELANCERS_TOPIC, expect.any(Function))
     expect(subscribeToTopic).toHaveBeenCalledWith(FIVERR_GIGS_TOPIC, expect.any(Function))
+  })
+
+  it('publishes freelancer info and gig updates', async () => {
+    const agent = await FiverrAgent.create()
+    const [freelancer] = await agent.analyzeTopFreelancers('design')
+    expect(sendMessage).toHaveBeenCalledWith(FIVERR_FREELANCERS_TOPIC, freelancer)
+    expect(agent.freelancers[0]).toEqual(freelancer)
+
+    const [gig] = await agent.updateGigs()
+    expect(sendMessage).toHaveBeenCalledWith(FIVERR_GIGS_TOPIC, gig)
+    expect(agent.gigs[0]).toEqual(gig)
+
+    const fMsg = { id: 'x', name: 'n', rating: 5 }
+    handlers[FIVERR_FREELANCERS_TOPIC](fMsg, {})
+    expect(agent.freelancers).toContainEqual(fMsg)
+
+    const gMsg = { id: 'y', title: 'Gig 1', updatedAt: 'now' }
+    handlers[FIVERR_GIGS_TOPIC](gMsg, {})
+    expect(agent.gigs).toContainEqual(gMsg)
+  })
+
+  it('cleans up subscriptions on close', async () => {
+    subscribeToTopic.mockResolvedValueOnce({ unsubscribe: vi.fn() })
+    subscribeToTopic.mockResolvedValueOnce({ unsubscribe: vi.fn() })
+    const agent = await FiverrAgent.create()
+    const unsub1 = (await subscribeToTopic.mock.results[0].value).unsubscribe
+    const unsub2 = (await subscribeToTopic.mock.results[1].value).unsubscribe
+    await agent.close()
+    expect(unsub1).toHaveBeenCalled()
+    expect(unsub2).toHaveBeenCalled()
+    expect(disconnect).toHaveBeenCalled()
   })
 })

--- a/src/__tests__/InstagramAgent.test.ts
+++ b/src/__tests__/InstagramAgent.test.ts
@@ -40,7 +40,7 @@ let CAPTIONS_TOPIC: string
 beforeEach(async () => {
   const mod = await import('../agents/InstagramAgent')
   InstagramAgent = mod.InstagramAgent
-  ;({ ACCOUNT_TOPIC, IDEAS_TOPIC, ENGAGEMENT_TOPIC } = await import('../lib/wakuTopics'))
+  ;({ ACCOUNT_TOPIC, IDEAS_TOPIC, ENGAGEMENT_TOPIC, CAPTIONS_TOPIC } = await import('../lib/wakuTopics'))
   connect.mockClear()
   disconnect.mockClear()
   sendMessage.mockClear()
@@ -83,7 +83,10 @@ describe('InstagramAgent', () => {
     const hook = await agent.analyzeAccount(acc.id)
     expect(hook).toContain(acc.id)
     expect(sendMessage).toHaveBeenCalledWith(IDEAS_TOPIC, expect.objectContaining({ accountId: acc.id }))
-    expect(sendMessage).toHaveBeenCalledWith(CAPTIONS_TOPIC, expect.objectContaining({ accountId: acc.id }))
+    expect(sendMessage).toHaveBeenCalledWith(
+      CAPTIONS_TOPIC,
+      expect.objectContaining({ accountId: acc.id })
+    )
     const ideas = await agent.suggestDailyContent()
     expect(ideas.length).toBe(1)
     expect(ideas[0].accountId).toBe(acc.id)


### PR DESCRIPTION
## Summary
- expand FiverrAgent test coverage
- fix InstagramAgent test
- ensure captions topic variable is loaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a713348b4832680c7923e91ba4fa8