### PR TITLE
Fix wa-sqlite type import

### DIFF
--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -1,6 +1,7 @@
 // Local SQLite database initialisation.
 // Uses an in-memory database so no file is created.
-import './wa-sqlite.d.ts'
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="./wa-sqlite.d.ts" />
 
 async function run() {
   try {


### PR DESCRIPTION
## Summary
- reference wa-sqlite types without runtime import

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run dev` *(launches Vite dev server)*

------
https://chatgpt.com/codex/tasks/task_e_688b5947706c832699192d14cb3ca5c6