### PR TITLE
Add setup page for config

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { SubscriptionManager } from "./components/subscription/SubscriptionManag
 import { ProtectedRoute } from "./components/ProtectedRoute"
 import { Onboarding } from "./pages/Onboarding"
 import { SettingsPage } from "./pages/Settings"
+import { SetupPage } from "./components/SetupPage"
 
 function App() {
   if (import.meta.env.DEV) console.log("App component is rendering");
@@ -60,6 +61,12 @@ function App() {
             (() => {
               if (import.meta.env.DEV) console.log("Rendering Onboarding for route /onboarding");
               return <ProtectedRoute> <Onboarding /> </ProtectedRoute>;
+            })()
+          } />
+          <Route path="/setup" element={
+            (() => {
+              if (import.meta.env.DEV) console.log("Rendering SetupPage for route /setup");
+              return <SetupPage />;
             })()
           } />
           <Route path="/settings" element={

--- a/src/components/SetupPage.tsx
+++ b/src/components/SetupPage.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { saveConfig, AppConfig } from '@/services/ConfigService'
+import { useNavigate } from 'react-router-dom'
+
+export function SetupPage() {
+  const navigate = useNavigate()
+  const [apiBaseUrl, setApiBaseUrl] = useState('http://localhost:3000')
+  const [openaiApiKey, setOpenaiApiKey] = useState('')
+  const [elevenLabsApiKey, setElevenLabsApiKey] = useState('')
+  const [enableWaku, setEnableWaku] = useState(false)
+  const [wakuRelayUrl, setWakuRelayUrl] = useState('')
+
+  const handleSave = async () => {
+    const cfg: AppConfig = {
+      apiBaseUrl,
+      openaiApiKey,
+      elevenLabsApiKey: elevenLabsApiKey || undefined,
+      enableWaku,
+      wakuRelayUrl: wakuRelayUrl || undefined
+    }
+    await saveConfig(cfg)
+    navigate('/')
+    window.location.reload()
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Initial Setup</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>API Base URL</Label>
+            <Input
+              value={apiBaseUrl}
+              onChange={e => setApiBaseUrl(e.target.value)}
+              placeholder="http://localhost:3000"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>OpenAI API Key</Label>
+            <Input
+              type="password"
+              value={openaiApiKey}
+              onChange={e => setOpenaiApiKey(e.target.value)}
+              placeholder="sk-..."
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>ElevenLabs API Key</Label>
+            <Input
+              type="password"
+              value={elevenLabsApiKey}
+              onChange={e => setElevenLabsApiKey(e.target.value)}
+              placeholder="optional"
+            />
+          </div>
+          <div className="flex items-center space-x-2">
+            <Switch checked={enableWaku} onCheckedChange={setEnableWaku} />
+            <Label>Enable Waku Messaging</Label>
+          </div>
+          <div className="space-y-2">
+            <Label>Waku Relay Multiaddress</Label>
+            <Input
+              value={wakuRelayUrl}
+              onChange={e => setWakuRelayUrl(e.target.value)}
+              placeholder="/dns4/node/..."
+            />
+          </div>
+          <Button className="w-full" onClick={handleSave}>Save</Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default SetupPage

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -88,15 +88,12 @@ export async function importConfig(json: string): Promise<void> {
 }
 
 export async function ensureConfig(): Promise<AppConfig> {
-  let cfg = await loadConfig()
+  const cfg = await loadConfig()
   if (!cfg) {
-    const apiBaseUrl = window.prompt('API base URL (e.g. http://localhost:3000)') || ''
-    const openaiApiKey = window.prompt('OpenAI API key') || ''
-    const elevenLabsApiKey = window.prompt('ElevenLabs API key (optional)') || undefined
-    const enableWaku = window.confirm('Enable Waku messaging?')
-    const wakuRelayUrl = window.prompt('Waku relay multiaddress (optional)') || undefined
-    cfg = { apiBaseUrl, openaiApiKey, elevenLabsApiKey, enableWaku, wakuRelayUrl }
-    await saveConfig(cfg)
+    if (!window.location.pathname.startsWith('/setup')) {
+      window.location.assign('/setup')
+    }
+    throw new Error('Missing configuration')
   }
   return cfg
 }


### PR DESCRIPTION
## Summary
- add SetupPage for entering API and Waku settings
- route `/setup` to SetupPage
- redirect to `/setup` in ConfigService when configuration is missing

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bdc5868988326b9967808f159ed4a