### PR TITLE
Add configuration setup page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { SubscriptionManager } from "./components/subscription/SubscriptionManag
 import { ProtectedRoute } from "./components/ProtectedRoute"
 import { Onboarding } from "./pages/Onboarding"
 import { SettingsPage } from "./pages/Settings"
-import { SetupPage } from "./components/SetupPage"
+import { ConfigSetup } from "./components/ConfigSetup"
 
 function App() {
   if (import.meta.env.DEV) console.log("App component is rendering");
@@ -63,10 +63,10 @@ function App() {
               return <ProtectedRoute> <Onboarding /> </ProtectedRoute>;
             })()
           } />
-          <Route path="/setup" element={
+          <Route path="/config" element={
             (() => {
-              if (import.meta.env.DEV) console.log("Rendering SetupPage for route /setup");
-              return <SetupPage />;
+              if (import.meta.env.DEV) console.log("Rendering ConfigSetup for route /config");
+              return <ConfigSetup />;
             })()
           } />
           <Route path="/settings" element={

--- a/src/components/ConfigSetup.tsx
+++ b/src/components/ConfigSetup.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { saveConfig, AppConfig } from '@/services/ConfigService'
+import { useNavigate } from 'react-router-dom'
+
+export function ConfigSetup() {
+  const navigate = useNavigate()
+  const [apiBaseUrl, setApiBaseUrl] = useState('http://localhost:3000')
+  const [openaiApiKey, setOpenaiApiKey] = useState('')
+  const [elevenLabsApiKey, setElevenLabsApiKey] = useState('')
+  const [enableWaku, setEnableWaku] = useState(false)
+  const [wakuRelayUrl, setWakuRelayUrl] = useState('')
+
+  const handleSave = async () => {
+    const cfg: AppConfig = {
+      apiBaseUrl,
+      openaiApiKey,
+      elevenLabsApiKey: elevenLabsApiKey || undefined,
+      enableWaku,
+      wakuRelayUrl: wakuRelayUrl || undefined
+    }
+    await saveConfig(cfg)
+    navigate('/')
+    window.location.reload()
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Initial Setup</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>API Base URL</Label>
+            <Input
+              value={apiBaseUrl}
+              onChange={e => setApiBaseUrl(e.target.value)}
+              placeholder="http://localhost:3000"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>OpenAI API Key</Label>
+            <Input
+              type="password"
+              value={openaiApiKey}
+              onChange={e => setOpenaiApiKey(e.target.value)}
+              placeholder="sk-..."
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>ElevenLabs API Key</Label>
+            <Input
+              type="password"
+              value={elevenLabsApiKey}
+              onChange={e => setElevenLabsApiKey(e.target.value)}
+              placeholder="optional"
+            />
+          </div>
+          <div className="flex items-center space-x-2">
+            <Switch checked={enableWaku} onCheckedChange={setEnableWaku} />
+            <Label>Enable Waku Messaging</Label>
+          </div>
+          <div className="space-y-2">
+            <Label>Waku Relay Multiaddress</Label>
+            <Input
+              value={wakuRelayUrl}
+              onChange={e => setWakuRelayUrl(e.target.value)}
+              placeholder="/dns4/node/..."
+            />
+          </div>
+          <Button className="w-full" onClick={handleSave}>Save</Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default ConfigSetup

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -14,6 +15,7 @@ import {
 } from '@/services/BrainSettingsService';
 
 export function SettingsPage() {
+  const navigate = useNavigate();
   const [voiceEnabled, setVoiceEnabled] = useState<boolean>(false);
   const [voiceLanguage, setVoiceLanguage] = useState('en-US');
   const [apiKey, setApiKey] = useState('');
@@ -133,6 +135,9 @@ export function SettingsPage() {
             }} />
           </div>
           <Button onClick={saveSettings}>Save</Button>
+          <Button variant="secondary" onClick={() => navigate('/config')}>
+            Configure App
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -90,8 +90,8 @@ export async function importConfig(json: string): Promise<void> {
 export async function ensureConfig(): Promise<AppConfig> {
   const cfg = await loadConfig()
   if (!cfg) {
-    if (!window.location.pathname.startsWith('/setup')) {
-      window.location.assign('/setup')
+    if (!window.location.pathname.startsWith('/config')) {
+      window.location.assign('/config')
     }
     throw new Error('Missing configuration')
   }


### PR DESCRIPTION
## Summary
- create `ConfigSetup` for capturing API details
- route `/config` to the new setup page
- redirect to `/config` when configuration is missing
- link from Settings page to reopen configuration UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bdf965b0c8326b98fc5bd7d44ae01