### PR TITLE
Add GameWorld with React Three Fiber

### DIFF
--- a/src/components/dashboard/AuraLayout.tsx
+++ b/src/components/dashboard/AuraLayout.tsx
@@ -29,6 +29,7 @@ import { useCharacter } from '@/hooks/useCharacter';
 import { SkillTree } from '@/components/rpg/SkillTree';
 import { useNavigate } from 'react-router-dom';
 import { AuraMemoryService } from '@/services/AuraMemoryService';
+import { GameWorld } from '@/game/GameWorld';
 
 const jobIcons = {
   'Strategist': Crown,
@@ -53,6 +54,7 @@ function AuraLayoutContent() {
   const [showPlanModal, setShowPlanModal] = useState(false);
   const [planType, setPlanType] = useState<'life' | 'project'>('project');
   const [isCreatingProject, setIsCreatingProject] = useState(false);
+  const [showGameWorld, setShowGameWorld] = useState(false);
 
   const { handleWidgetAction } = useChatContext();
   const { character, isLoading, xpAnimation, levelUpAnimation } = useCharacter();
@@ -285,6 +287,8 @@ function AuraLayoutContent() {
           <FloatingActionButtons
             onOpenRoadmap={() => setShowRoadmapModal(true)}
             onOpenQuestLog={() => setShowQuestLog(true)}
+            onToggleGameWorld={() => setShowGameWorld(!showGameWorld)}
+            gameActive={showGameWorld}
           />
         )}
 
@@ -293,6 +297,8 @@ function AuraLayoutContent() {
           <FloatingActionButtons
             onOpenRoadmap={() => setShowRoadmapModal(true)}
             onOpenQuestLog={() => setShowQuestLog(true)}
+            onToggleGameWorld={() => setShowGameWorld(!showGameWorld)}
+            gameActive={showGameWorld}
           />
         )}
 
@@ -505,6 +511,18 @@ function AuraLayoutContent() {
             <RewardsModal />
           </DialogContent>
         </Dialog>
+
+        {showGameWorld && (
+          <div className="fixed inset-0 z-50">
+            <GameWorld />
+            <button
+              onClick={() => setShowGameWorld(false)}
+              className="absolute top-4 right-4 bg-white/80 text-black px-3 py-1 rounded"
+            >
+              Close
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/rpg/FloatingActionButtons.tsx
+++ b/src/components/rpg/FloatingActionButtons.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
-import { Map, Scroll } from 'lucide-react';
+import { Map, Scroll, Gamepad } from 'lucide-react';
 
 interface FloatingActionButtonsProps {
   onOpenRoadmap: () => void;
   onOpenQuestLog: () => void;
+  onToggleGameWorld: () => void;
+  gameActive?: boolean;
 }
 
-export function FloatingActionButtons({ onOpenRoadmap, onOpenQuestLog }: FloatingActionButtonsProps) {
+export function FloatingActionButtons({ onOpenRoadmap, onOpenQuestLog, onToggleGameWorld, gameActive }: FloatingActionButtonsProps) {
   return (
     <div className="fixed bottom-20 right-4 z-40 flex flex-col space-y-3">
       <motion.div
@@ -36,6 +38,20 @@ export function FloatingActionButtons({ onOpenRoadmap, onOpenQuestLog }: Floatin
           className="w-14 h-14 rounded-full bg-gradient-to-r from-green-500 to-teal-600 hover:from-green-600 hover:to-teal-700 shadow-lg"
         >
           <Scroll className="w-6 h-6" />
+        </Button>
+      </motion.div>
+
+      <motion.div
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        transition={{ delay: 0.9 }}
+      >
+        <Button
+          onClick={onToggleGameWorld}
+          size="icon"
+          className={`w-14 h-14 rounded-full shadow-lg ${gameActive ? 'bg-red-600 hover:bg-red-700' : 'bg-indigo-500 hover:bg-indigo-600'}`}
+        >
+          <Gamepad className="w-6 h-6" />
         </Button>
       </motion.div>
     </div>

--- a/src/game/GameWorld.tsx
+++ b/src/game/GameWorld.tsx
@@ -1,0 +1,69 @@
+import React, { Suspense, useEffect, useRef, useState } from 'react'
+
+export function GameWorld() {
+  const [ready, setReady] = useState(false)
+  const CanvasRef = useRef<any>(null)
+  const useFrameRef = useRef<any>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const fiber = await import('@react-three/fiber')
+        if (!cancelled) {
+          CanvasRef.current = fiber.Canvas
+          useFrameRef.current = fiber.useFrame
+          setReady(true)
+        }
+      } catch (err) {
+        console.error('Failed to load three.js', err)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (!ready) {
+    return <div className="w-full h-full bg-black text-white flex items-center justify-center">Loading 3D...</div>
+  }
+
+  const Canvas = CanvasRef.current as React.ComponentType<any>
+  const useFrame = useFrameRef.current as any
+
+  const SpinningBox = () => {
+    const mesh = useRef<any>(null)
+    useFrame(() => {
+      if (mesh.current) {
+        mesh.current.rotation.x += 0.01
+        mesh.current.rotation.y += 0.01
+      }
+    })
+    return (
+      <mesh ref={mesh}>
+        {/* @ts-expect-error three types not guaranteed */}
+        <boxGeometry args={[1, 1, 1]} />
+        {/* @ts-expect-error three types not guaranteed */}
+        <meshStandardMaterial color="orange" />
+      </mesh>
+    )
+  }
+
+  return (
+    <Canvas
+      className="w-full h-full"
+      camera={{ position: [0, 0, 5], fov: 60 }}
+    >
+      {/* @ts-expect-error -- three types not guaranteed */}
+      <ambientLight intensity={0.5} />
+      {/* @ts-expect-error -- three types not guaranteed */}
+      <directionalLight position={[5, 5, 5]} />
+      <Suspense fallback={null}>
+        <SpinningBox />
+      </Suspense>
+    </Canvas>
+  )
+}
+
+export default GameWorld


### PR DESCRIPTION
## Summary
- create `GameWorld` component with React Three Fiber canvas
- add toggle in floating action buttons
- show the 3D world overlay from `AuraLayout`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bdf96f71c8326af3a6f9f5d0a6a7a