### PR TITLE
Add ECS framework and initial game scenes

### DIFF
--- a/src/__tests__/wakuTopics.test.ts
+++ b/src/__tests__/wakuTopics.test.ts
@@ -8,5 +8,6 @@ describe('wakuTopics', () => {
     expect(wakuTopics.userProfile(key)).toBe(`/aura/users/${key}/profile`)
     expect(wakuTopics.userConfig(key)).toBe(`/aura/users/${key}/config`)
     expect(wakuTopics.userTraits(key)).toBe(`/aura/users/${key}/traits`)
+    expect(wakuTopics.playerState).toBe('/aura/game/player-state/1/app')
   })
 })

--- a/src/game/hooks/usePlayerBroadcast.ts
+++ b/src/game/hooks/usePlayerBroadcast.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react'
+import { connect, sendOnTopic } from '@/lib/waku'
+import { wakuTopics } from '@/lib/wakuTopics'
+
+export interface PlayerState {
+  id: string
+  position: { x: number; y: number }
+}
+
+export function usePlayerBroadcast(state: PlayerState | null) {
+  const prev = useRef<PlayerState | null>(null)
+
+  useEffect(() => {
+    if (!state) return
+    if (
+      prev.current &&
+      prev.current.position.x === state.position.x &&
+      prev.current.position.y === state.position.y
+    ) {
+      return
+    }
+    prev.current = state
+    async function publish() {
+      try {
+        await connect()
+        await sendOnTopic(wakuTopics.playerState, state)
+      } catch (err) {
+        console.warn('[waku] failed to broadcast player state', err)
+      }
+    }
+    publish()
+  }, [state])
+}

--- a/src/game/scenes/Hub.tsx
+++ b/src/game/scenes/Hub.tsx
@@ -1,0 +1,11 @@
+import GameWorld from '../GameWorld'
+
+export function Hub() {
+  return (
+    <div className="w-full h-full">
+      <GameWorld />
+    </div>
+  )
+}
+
+export default Hub

--- a/src/game/scenes/Marketplace.tsx
+++ b/src/game/scenes/Marketplace.tsx
@@ -1,0 +1,11 @@
+import GameWorld from '../GameWorld'
+
+export function Marketplace() {
+  return (
+    <div className="w-full h-full">
+      <GameWorld />
+    </div>
+  )
+}
+
+export default Marketplace

--- a/src/game/scenes/PlayerHome.tsx
+++ b/src/game/scenes/PlayerHome.tsx
@@ -1,0 +1,11 @@
+import GameWorld from '../GameWorld'
+
+export function PlayerHome() {
+  return (
+    <div className="w-full h-full">
+      <GameWorld />
+    </div>
+  )
+}
+
+export default PlayerHome

--- a/src/game/systems/ecs.ts
+++ b/src/game/systems/ecs.ts
@@ -1,0 +1,58 @@
+export type Entity = number
+
+export class World {
+  private nextId = 1
+  private components = new Map<string, Map<Entity, any>>()
+
+  createEntity(): Entity {
+    return this.nextId++
+  }
+
+  addComponent<T>(entity: Entity, name: string, data: T): void {
+    let bucket = this.components.get(name)
+    if (!bucket) {
+      bucket = new Map<Entity, T>()
+      this.components.set(name, bucket)
+    }
+    bucket.set(entity, data)
+  }
+
+  getComponent<T>(entity: Entity, name: string): T | undefined {
+    return this.components.get(name)?.get(entity)
+  }
+
+  removeComponent(entity: Entity, name: string): void {
+    this.components.get(name)?.delete(entity)
+  }
+
+  removeEntity(entity: Entity): void {
+    for (const bucket of this.components.values()) {
+      bucket.delete(entity)
+    }
+  }
+
+  query(...names: string[]) {
+    const results: Array<{ entity: Entity; components: Record<string, any> }> = []
+    const first = this.components.get(names[0])
+    if (!first) return results
+    for (const [entity, data] of first.entries()) {
+      const components: Record<string, any> = { [names[0]]: data }
+      let ok = true
+      for (let i = 1; i < names.length; i++) {
+        const bucket = this.components.get(names[i])
+        if (!bucket) {
+          ok = false
+          break
+        }
+        const comp = bucket.get(entity)
+        if (comp === undefined) {
+          ok = false
+          break
+        }
+        components[names[i]] = comp
+      }
+      if (ok) results.push({ entity, components })
+    }
+    return results
+  }
+}

--- a/src/game/systems/index.ts
+++ b/src/game/systems/index.ts
@@ -1,0 +1,4 @@
+export * from './ecs'
+export * from './movement'
+export * from './rendering'
+export * from './interactions'

--- a/src/game/systems/interactions.ts
+++ b/src/game/systems/interactions.ts
@@ -1,0 +1,22 @@
+import { World, Entity } from './ecs'
+import type { Position } from './movement'
+
+export type InteractionCallback = (other: Entity) => void
+
+export function interactionSystem(world: World) {
+  const entities = world.query('position', 'onInteract')
+  for (let i = 0; i < entities.length; i++) {
+    const a = entities[i]
+    for (let j = i + 1; j < entities.length; j++) {
+      const b = entities[j]
+      const pa = a.components.position as Position
+      const pb = b.components.position as Position
+      if (Math.abs(pa.x - pb.x) < 1 && Math.abs(pa.y - pb.y) < 1) {
+        const ia = a.components.onInteract as InteractionCallback
+        const ib = b.components.onInteract as InteractionCallback
+        ia(b.entity)
+        ib(a.entity)
+      }
+    }
+  }
+}

--- a/src/game/systems/movement.ts
+++ b/src/game/systems/movement.ts
@@ -1,0 +1,15 @@
+import { World, Entity } from './ecs'
+
+export interface Position { x: number; y: number }
+export interface Velocity { x: number; y: number }
+
+export function movementSystem(world: World, dt: number) {
+  const entities = world.query('position', 'velocity')
+  for (const { entity, components } of entities) {
+    const pos = components.position as Position
+    const vel = components.velocity as Velocity
+    pos.x += vel.x * dt
+    pos.y += vel.y * dt
+    world.addComponent(entity, 'position', pos)
+  }
+}

--- a/src/game/systems/rendering.ts
+++ b/src/game/systems/rendering.ts
@@ -1,0 +1,13 @@
+import { World } from './ecs'
+import type { Position } from './movement'
+
+export type RenderCallback = (pos: Position) => void
+
+export function renderingSystem(world: World) {
+  const entities = world.query('position', 'render')
+  for (const { components } of entities) {
+    const pos = components.position as Position
+    const render = components.render as RenderCallback
+    render({ ...pos })
+  }
+}

--- a/src/lib/wakuTopics.ts
+++ b/src/lib/wakuTopics.ts
@@ -14,6 +14,7 @@ export const wakuTopics = {
   fiverrFreelancers: '/aura/fiverr-agent/freelancers/1/app',
   fiverrGigs: '/aura/fiverr-agent/gigs/1/app',
   ideaMappings: '/aura/idea-mapper/mappings/1/app',
+  playerState: '/aura/game/player-state/1/app',
   userProfile: (pubkey: string) => `/aura/users/${pubkey}/profile`,
   userConfig: (pubkey: string) => `/aura/users/${pubkey}/config`,
   userTraits: (pubkey: string) => `/aura/users/${pubkey}/traits`
@@ -31,6 +32,7 @@ export const PROGRESS_TOPIC = wakuTopics.growthProgress;
 export const FIVERR_FREELANCERS_TOPIC = wakuTopics.fiverrFreelancers;
 export const FIVERR_GIGS_TOPIC = wakuTopics.fiverrGigs;
 export const IDEA_MAPPINGS_TOPIC = wakuTopics.ideaMappings;
+export const PLAYER_STATE_TOPIC = wakuTopics.playerState;
 
 export type WakuTopic = typeof wakuTopics[keyof typeof wakuTopics];
 


### PR DESCRIPTION
## Summary
- add `Hub`, `PlayerHome`, and `Marketplace` scenes
- implement a small ECS with movement, rendering and interaction systems
- provide `usePlayerBroadcast` hook to send player state via Waku
- expose new `playerState` topic in `wakuTopics`
- update tests for new Waku topic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688be1f3fd508326a6c6378497271906