### PR TITLE
Add mission wrappers and Growth NPC

### DIFF
--- a/src/__tests__/AuraGrowthAgentWrapper.test.ts
+++ b/src/__tests__/AuraGrowthAgentWrapper.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const triggerInstagramCycle = vi.fn()
+const close = vi.fn()
+const create = vi.fn(async () => ({ triggerInstagramCycle, close }))
+
+vi.mock('../agents/AuraGrowthAgent', () => ({ AuraGrowthAgent: { create } }))
+
+let AuraGrowthAgentWrapper: any
+
+beforeEach(async () => {
+  const mod = await import('../agents/AuraGrowthAgentWrapper')
+  AuraGrowthAgentWrapper = mod.AuraGrowthAgentWrapper
+  create.mockClear()
+  triggerInstagramCycle.mockClear()
+  close.mockClear()
+})
+
+describe('AuraGrowthAgentWrapper', () => {
+  it('exposes growth mission hook', async () => {
+    const wrapper = await AuraGrowthAgentWrapper.create()
+    await wrapper.missionHooks.growthCycle('fitness')
+    expect(create).toHaveBeenCalled()
+    expect(triggerInstagramCycle).toHaveBeenCalledWith('fitness')
+  })
+})

--- a/src/agents/AuraGrowthAgentWrapper.ts
+++ b/src/agents/AuraGrowthAgentWrapper.ts
@@ -1,0 +1,24 @@
+import { AuraGrowthAgent } from './AuraGrowthAgent'
+
+export interface AuraGrowthMissionHooks {
+  growthCycle: (niche: string) => Promise<void>
+}
+
+export class AuraGrowthAgentWrapper {
+  private constructor(private agent: AuraGrowthAgent) {}
+
+  static async create(): Promise<AuraGrowthAgentWrapper> {
+    const agent = await AuraGrowthAgent.create()
+    return new AuraGrowthAgentWrapper(agent)
+  }
+
+  missionHooks: AuraGrowthMissionHooks = {
+    growthCycle: async (niche: string) => {
+      await this.agent.triggerInstagramCycle(niche)
+    }
+  }
+
+  async close() {
+    await this.agent.close()
+  }
+}

--- a/src/agents/FiverrAgentWrapper.ts
+++ b/src/agents/FiverrAgentWrapper.ts
@@ -1,0 +1,28 @@
+import { FiverrAgent } from './FiverrAgent'
+
+export interface FiverrMissionHooks {
+  analyzeFreelancers: (category: string) => Promise<void>
+  updateGigs: () => Promise<void>
+}
+
+export class FiverrAgentWrapper {
+  private constructor(private agent: FiverrAgent) {}
+
+  static async create(): Promise<FiverrAgentWrapper> {
+    const agent = await FiverrAgent.create()
+    return new FiverrAgentWrapper(agent)
+  }
+
+  missionHooks: FiverrMissionHooks = {
+    analyzeFreelancers: async (category: string) => {
+      await this.agent.analyzeTopFreelancers(category)
+    },
+    updateGigs: async () => {
+      await this.agent.updateGigs()
+    }
+  }
+
+  async close() {
+    await this.agent.close()
+  }
+}

--- a/src/agents/InstagramAgentWrapper.ts
+++ b/src/agents/InstagramAgentWrapper.ts
@@ -1,0 +1,24 @@
+import { InstagramAgent } from './InstagramAgent'
+
+export interface InstagramMissionHooks {
+  dailyContent: (niche: string) => Promise<void>
+}
+
+export class InstagramAgentWrapper {
+  private constructor(private agent: InstagramAgent) {}
+
+  static async create(): Promise<InstagramAgentWrapper> {
+    const agent = await InstagramAgent.create()
+    return new InstagramAgentWrapper(agent)
+  }
+
+  missionHooks: InstagramMissionHooks = {
+    dailyContent: async (niche: string) => {
+      await this.agent.runDailyCycle(niche)
+    }
+  }
+
+  async close() {
+    await this.agent.close()
+  }
+}

--- a/src/agents/YouTubeAgentWrapper.ts
+++ b/src/agents/YouTubeAgentWrapper.ts
@@ -1,0 +1,29 @@
+import { YouTubeAgent } from './YouTubeAgent'
+
+export interface YouTubeMissionHooks {
+  analyzeVideo: (
+    id: string,
+    title: string,
+    thumbnail: string,
+    script: string
+  ) => Promise<void>
+}
+
+export class YouTubeAgentWrapper {
+  private constructor(private agent: YouTubeAgent) {}
+
+  static async create(): Promise<YouTubeAgentWrapper> {
+    const agent = await YouTubeAgent.create()
+    return new YouTubeAgentWrapper(agent)
+  }
+
+  missionHooks: YouTubeMissionHooks = {
+    analyzeVideo: async (id, title, thumbnail, script) => {
+      await this.agent.analyzeVideo(id, title, thumbnail, script)
+    }
+  }
+
+  async close() {
+    await this.agent.close()
+  }
+}

--- a/src/game/GameWorld.tsx
+++ b/src/game/GameWorld.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, useEffect, useRef, useState } from 'react'
+import GrowthNPC from './components/GrowthNPC'
 
 export function GameWorld() {
   const [ready, setReady] = useState(false)
@@ -51,18 +52,21 @@ export function GameWorld() {
   }
 
   return (
-    <Canvas
-      className="w-full h-full"
-      camera={{ position: [0, 0, 5], fov: 60 }}
-    >
-      {/* @ts-expect-error -- three types not guaranteed */}
-      <ambientLight intensity={0.5} />
-      {/* @ts-expect-error -- three types not guaranteed */}
-      <directionalLight position={[5, 5, 5]} />
-      <Suspense fallback={null}>
-        <SpinningBox />
-      </Suspense>
-    </Canvas>
+    <div className="relative w-full h-full">
+      <Canvas
+        className="w-full h-full"
+        camera={{ position: [0, 0, 5], fov: 60 }}
+      >
+        {/* @ts-expect-error -- three types not guaranteed */}
+        <ambientLight intensity={0.5} />
+        {/* @ts-expect-error -- three types not guaranteed */}
+        <directionalLight position={[5, 5, 5]} />
+        <Suspense fallback={null}>
+          <SpinningBox />
+        </Suspense>
+      </Canvas>
+      <GrowthNPC />
+    </div>
   )
 }
 

--- a/src/game/components/GrowthNPC.tsx
+++ b/src/game/components/GrowthNPC.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { subscribeToTopic, PROGRESS_TOPIC } from '@/lib/wakuTopics'
+import type { ProgressReport } from '@/agents/AuraGrowthAgent'
+
+export function GrowthNPC() {
+  const [events, setEvents] = useState<ProgressReport[]>([])
+  useEffect(() => {
+    let sub: { unsubscribe: () => Promise<void> } | null = null
+    async function start() {
+      sub = await subscribeToTopic<ProgressReport>(PROGRESS_TOPIC, data =>
+        setEvents(prev => [...prev.slice(-4), data])
+      )
+    }
+    start()
+    return () => {
+      if (sub) sub.unsubscribe()
+    }
+  }, [])
+
+  return (
+    <div className="absolute bottom-2 left-2 bg-black/50 text-white text-xs p-2 rounded">
+      <div className="font-bold">Growth NPC</div>
+      {events.map((e, idx) => (
+        <div key={idx}>
+          {new Date(e.timestamp).toLocaleTimeString()}: {e.accounts} accounts, {e.ideas} ideas
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default GrowthNPC


### PR DESCRIPTION
## Summary
- create wrapper classes for each agent with mission hooks
- add Growth NPC component subscribed to AuraGrowthAgent progress
- overlay Growth NPC in GameWorld
- test wrapper for AuraGrowthAgent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be580f3d88326885c1c32f5750844