### PR TITLE
Remove unused initDatabase from startup

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,7 +43,6 @@ window.addEventListener('unhandledrejection', (event) => {
 
 async function start() {
   try {
-    await initDatabase()
     const cfg = await loadConfig()
     if (cfg) {
       setBaseURL(cfg.apiBaseUrl)


### PR DESCRIPTION
## Summary
- remove `initDatabase` invocation from `src/main.tsx`

## Testing
- `npm test`
- `npm run lint`
- `timeout 5 npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688bebfbdb948326ab0c6abe0e5f04e3