### PR TITLE
Fix Waku initialization

### DIFF
--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -7,22 +7,22 @@ import {
   DecodedMessage
 } from '@waku/sdk'
 import type { WakuTopic } from './wakuTopics'
-import { loadConfig } from '@/services/ConfigService'
 
 const CONTENT_TOPIC = '/lifepilot/1/chat'
 
 let node: LightNode | null = null
 
-let VITE_WAKU_RELAY_URL: string | undefined
-loadConfig().then(cfg => {
-  VITE_WAKU_RELAY_URL = cfg?.wakuRelayUrl
-})
+let wakuRelayUrl: string | undefined
+
+export function setRelayUrl(url?: string) {
+  wakuRelayUrl = url
+}
 
 export async function connect(): Promise<LightNode> {
   if (node) return node
   node = await createLightNode(
-    VITE_WAKU_RELAY_URL
-      ? { bootstrapPeers: [VITE_WAKU_RELAY_URL] }
+    wakuRelayUrl
+      ? { bootstrapPeers: [wakuRelayUrl] }
       : { defaultBootstrap: true }
   )
   await node.start()

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import './index.css'
 import { loadBrainSettings } from './services/BrainSettingsService'
 import { loadConfig } from './services/ConfigService'
 import { setBaseURL } from './api/api'
+import { setRelayUrl } from './lib/waku'
 
 // Suppress console.log statements in production builds
 if (import.meta.env.PROD) {
@@ -47,6 +48,7 @@ async function start() {
     const cfg = await loadConfig()
     if (cfg) {
       setBaseURL(cfg.apiBaseUrl)
+      setRelayUrl(cfg.wakuRelayUrl)
       if (import.meta.env.DEV) console.log('[Main] Loaded config', cfg)
     } else if (import.meta.env.DEV) {
       console.log('[Main] No configuration found')


### PR DESCRIPTION
## Summary
- avoid circular dependency by removing `loadConfig()` call from `waku.ts`
- expose `setRelayUrl` for configuring the Waku relay
- set relay URL in `main.tsx` after loading the user configuration

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bebfe806c8326945c50eb451dc3b9