### PR TITLE
Fix auth identity init

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -31,12 +31,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [user])
 
   useEffect(() => {
-    WakuIdentityService.getIdentity().then(identity => {
-      if (identity) {
-        setUser(identity)
-        setIsAuthenticated(true)
-      }
-    })
+    const identity = WakuIdentityService.getIdentity()
+    if (identity) {
+      setUser(identity)
+      setIsAuthenticated(true)
+    }
   }, [])
   const login = async () => {
     const identity = await WakuIdentityService.createIdentity()

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -51,7 +51,7 @@ async function decrypt(data: string, secret: string): Promise<string> {
 }
 
 export async function loadConfig(): Promise<AppConfig | null> {
-  const identity = await WakuIdentityService.getIdentity()
+  const identity = WakuIdentityService.getIdentity()
   if (!identity) return null
   const row = await electric.settings.get(STORAGE_KEY)
   if (!row?.value) return null
@@ -64,7 +64,7 @@ export async function loadConfig(): Promise<AppConfig | null> {
 }
 
 export async function saveConfig(config: AppConfig): Promise<void> {
-  const identity = await WakuIdentityService.getIdentity()
+  const identity = WakuIdentityService.getIdentity()
   if (!identity) throw new Error('Missing identity')
   const json = JSON.stringify(config)
   const encrypted = await encrypt(json, identity.id)


### PR DESCRIPTION
## Summary
- initialize AuthContext state synchronously
- update ConfigService to use synchronous identity retrieval

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bf76609d48326bb11666054706147